### PR TITLE
`error` builtin to short-circuit execution. Closes #6

### DIFF
--- a/runtime/builtins.go
+++ b/runtime/builtins.go
@@ -17,6 +17,8 @@ package runtime
 import (
 	"context"
 	"fmt"
+
+	"github.com/sentrie-sh/sentrie/xerr"
 )
 
 type Builtin func(ctx context.Context, args []any) (any, error)
@@ -108,12 +110,12 @@ func BuiltInError(ctx context.Context, args []any) (any, error) {
 	}
 
 	if len(args) == 1 {
-		return nil, fmt.Errorf("%v", args[0])
+		args = append([]any{"%v"}, args...)
 	}
 
 	format := args[0].(string)
 	args = args[1:]
-	return nil, fmt.Errorf(format, args...)
+	return nil, xerr.ErrInjected(format, args...)
 }
 
 var Builtins = map[string]Builtin{

--- a/runtime/eval_call.go
+++ b/runtime/eval_call.go
@@ -74,6 +74,10 @@ func evalCall(ctx context.Context, ec *ExecutionContext, exec *executorImpl, p *
 	// call the target
 	out, err := wrappedTarget(ctx, args...)
 	if err != nil {
+		if errors.Is(err, xerr.InjectedError{}) {
+			// if this error is injected from code, we revert to the error message
+			return nil, n.SetErr(err), err
+		}
 		err = errors.Wrapf(err, "failed to call function '%s'", t.Callee.String())
 		return nil, n.SetErr(err), err
 	}

--- a/xerr/runtime.go
+++ b/xerr/runtime.go
@@ -20,6 +20,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Error injected by calling the `error` function in sentrie code
+type InjectedError struct {
+}
+
+func (e InjectedError) Error() string { return "runtime error" }
+
+func ErrInjected(format string, args ...any) error {
+	return errors.Wrapf(InjectedError{}, format, args...)
+}
+
 type InfiniteRecursionError struct{ stack []string }
 
 func (e InfiniteRecursionError) Error() string {


### PR DESCRIPTION
For a call like `error("hello world")` the error thrown is going to be:
```
Error: hello world: runtime error
```