### PR TITLE
Constructing `bool` as a special case of `trinary`

### DIFF
--- a/ast/gen.go
+++ b/ast/gen.go
@@ -41,7 +41,7 @@ func main() {
 	}{
 		{"genNumberConstraints", toAnyMap(constraints.NumberContraintCheckers)},
 		{"genStringConstraints", toAnyMap(constraints.StringContraintCheckers)},
-		{"genBoolConstraints", toAnyMap(constraints.BoolConstraintCheckers)},
+		{"genTrinaryConstraints", toAnyMap(constraints.TrinaryConstraintCheckers)},
 		{"genListConstraints", toAnyMap(constraints.ListContraintCheckers)},
 		{"genMapConstraints", toAnyMap(constraints.MapContraintCheckers)},
 		{"genDocumentConstraints", toAnyMap(constraints.DocumentContraintCheckers)},

--- a/ast/typeref_constraint_args_gen.go
+++ b/ast/typeref_constraint_args_gen.go
@@ -64,7 +64,7 @@ var genStringConstraints = map[string]int{
 	"uuid":              0,
 }
 
-var genBoolConstraints = map[string]int{
+var genTrinaryConstraints = map[string]int{
 	"eq":          1,
 	"is_false":    0,
 	"is_true":     0,

--- a/ast/typeref_trinary.go
+++ b/ast/typeref_trinary.go
@@ -16,23 +16,23 @@ package ast
 
 import "github.com/sentrie-sh/sentrie/tokens"
 
-type BoolTypeRef struct {
+type TrinaryTypeRef struct {
 	*baseTypeRef
 }
 
-func NewBoolTypeRef(ssp tokens.Range) *BoolTypeRef {
-	return &BoolTypeRef{
+func NewTrinaryTypeRef(ssp tokens.Range) *TrinaryTypeRef {
+	return &TrinaryTypeRef{
 		baseTypeRef: &baseTypeRef{
 			baseNode: &baseNode{
 				Rnge:  ssp,
-				Kind_: "boolean_typeref",
+				Kind_: "trinary_typeref",
 			},
-			validConstraints: genBoolConstraints,
+			validConstraints: genTrinaryConstraints,
 		},
 	}
 }
 
-var _ TypeRef = &BoolTypeRef{}
-var _ Node = &BoolTypeRef{}
+var _ TypeRef = &TrinaryTypeRef{}
+var _ Node = &TrinaryTypeRef{}
 
-func (b *BoolTypeRef) String() string { return "boolean" }
+func (b *TrinaryTypeRef) String() string { return "trinary" }

--- a/constraints/trinary.go
+++ b/constraints/trinary.go
@@ -22,10 +22,10 @@ import (
 	"github.com/sentrie-sh/sentrie/trinary"
 )
 
-// BoolConstraintCheckers contains supported boolean constraint validators.
-// For booleans, common constraints include eq/neq (compare to true/false),
+// TrinaryConstraintCheckers contains supported boolean constraint validators.
+// For trinaries, common constraints include eq/neq (compare to true/false/unknown),
 // and truthiness helpers like is_true/is_false.
-var BoolConstraintCheckers map[string]ConstraintDefinition[trinary.Value] = map[string]ConstraintDefinition[trinary.Value]{
+var TrinaryConstraintCheckers map[string]ConstraintDefinition[trinary.Value] = map[string]ConstraintDefinition[trinary.Value]{
 	"not_unknown": {
 		Name:    "not_unknown",
 		NumArgs: 0,

--- a/example_pack/minimal.sentrie
+++ b/example_pack/minimal.sentrie
@@ -67,8 +67,10 @@ policy var_test {
   let min: number = reduce numbers from numbers[0] as acc, num, idx {
     yield num < acc ? num : acc
   }
+  
+  let tri:trinary = unknown
 
-  rule errorRule = time.now()
+  rule errorRule = tri
 
   export decision of test
   export decision of errorRule

--- a/parser/let.go
+++ b/parser/let.go
@@ -31,6 +31,12 @@ func parseLetsStatement(ctx context.Context, p *Parser) ast.Statement {
 	if !found {
 		return nil
 	}
+
+	if nameIdent.Value == "tri" {
+		str := ""
+		_ = str
+	}
+
 	name := nameIdent.Value
 	rnge.To = nameIdent.Range.To
 

--- a/parser/lookups.go
+++ b/parser/lookups.go
@@ -118,6 +118,7 @@ var PRIMITIVE_TYPES = []tokens.Kind{
 	tokens.KeywordString,
 	tokens.KeywordNumber,
 	tokens.KeywordBoolean,
+	tokens.KeywordTrinary,
 	tokens.KeywordDocument,
 }
 

--- a/parser/typeref.go
+++ b/parser/typeref.go
@@ -38,8 +38,8 @@ func parseTypeRef(ctx context.Context, p *Parser) ast.TypeRef {
 		ref = ast.NewStringTypeRef(p.advance().Range)
 	case tokens.KeywordNumber:
 		ref = ast.NewNumberTypeRef(p.advance().Range)
-	case tokens.KeywordBoolean:
-		ref = ast.NewBoolTypeRef(p.advance().Range)
+	case tokens.KeywordBoolean, tokens.KeywordTrinary:
+		ref = ast.NewTrinaryTypeRef(p.advance().Range)
 	case tokens.Ident:
 		fqn := parseFQN(ctx, p)
 		if fqn == nil {

--- a/runtime/eval_cast.go
+++ b/runtime/eval_cast.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sentrie-sh/sentrie/ast"
 	"github.com/sentrie-sh/sentrie/index"
 	"github.com/sentrie-sh/sentrie/runtime/trace"
+	"github.com/sentrie-sh/sentrie/trinary"
 )
 
 func evalCast(ctx context.Context, ec *ExecutionContext, e *executorImpl, p *index.Policy, cast *ast.CastExpression) (any, *trace.Node, error) {
@@ -83,22 +84,15 @@ func evalCast(ctx context.Context, ec *ExecutionContext, e *executorImpl, p *ind
 			return nil, node.SetErr(err), err
 		}
 
-	case *ast.BoolTypeRef:
+	case *ast.TrinaryTypeRef:
 		switch v := val.(type) {
-		case bool:
-			result = v
+		case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+			result = trinary.From(v)
 		case string:
-			parsed, parseErr := strconv.ParseBool(v)
-			if parseErr != nil {
-				return nil, node.SetErr(parseErr), parseErr
-			}
+			parsed := trinary.Parse(v)
 			result = parsed
-		case int:
-			result = v != 0
-		case float64:
-			result = v != 0
 		default:
-			err = fmt.Errorf("cannot cast %T to bool", val)
+			err = fmt.Errorf("cannot cast %T to trinary value", val)
 			return nil, node.SetErr(err), err
 		}
 

--- a/runtime/typeref.go
+++ b/runtime/typeref.go
@@ -26,8 +26,8 @@ func validateValueAgainstTypeRef(ctx context.Context, ec *ExecutionContext, exec
 	switch t := typeRef.(type) {
 	case *ast.StringTypeRef:
 		return validateAgainstStringTypeRef(ctx, ec, exec, p, v, t, valueRange)
-	case *ast.BoolTypeRef:
-		return validateAgainstBoolTypeRef(ctx, ec, exec, p, v, t, valueRange)
+	case *ast.TrinaryTypeRef:
+		return validateAgainstTrinaryTypeRef(ctx, ec, exec, p, v, t, valueRange)
 	case *ast.NumberTypeRef:
 		return validateAgainstNumberTypeRef(ctx, ec, exec, p, v, t, valueRange)
 	case *ast.ListTypeRef:

--- a/runtime/typeref_trinary.go
+++ b/runtime/typeref_trinary.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sentrie-sh/sentrie/trinary"
 )
 
-func validateAgainstBoolTypeRef(ctx context.Context, ec *ExecutionContext, exec Executor, p *index.Policy, v any, typeRef *ast.BoolTypeRef, valueRange tokens.Range) error {
+func validateAgainstTrinaryTypeRef(ctx context.Context, ec *ExecutionContext, exec Executor, p *index.Policy, v any, typeRef *ast.TrinaryTypeRef, valueRange tokens.Range) error {
 	if b, ok := v.(bool); ok {
 		v = trinary.From(b)
 	}
@@ -44,7 +44,7 @@ func validateAgainstBoolTypeRef(ctx context.Context, ec *ExecutionContext, exec 
 			}
 			args[i] = csArg
 		}
-		checker, ok := constraints.BoolConstraintCheckers[constraint.Name]
+		checker, ok := constraints.TrinaryConstraintCheckers[constraint.Name]
 		if !ok {
 			return ErrUnknownConstraint(constraint)
 		}

--- a/runtime/typeref_trinary_test.go
+++ b/runtime/typeref_trinary_test.go
@@ -20,15 +20,16 @@ import (
 	"github.com/sentrie-sh/sentrie/ast"
 	"github.com/sentrie-sh/sentrie/index"
 	"github.com/sentrie-sh/sentrie/tokens"
+	"github.com/sentrie-sh/sentrie/trinary"
 )
 
 func (r *RuntimeTestSuite) TestValidateAgainstBoolTypeRef() {
-	typeRef := ast.NewBoolTypeRef(tokens.Range{File: "test.sentra", From: tokens.Pos{Line: 1, Column: 1, Offset: 0}, To: tokens.Pos{Line: 1, Column: 1, Offset: 0}})
+	typeRef := ast.NewTrinaryTypeRef(tokens.Range{File: "test.sentra", From: tokens.Pos{Line: 1, Column: 1, Offset: 0}, To: tokens.Pos{Line: 1, Column: 1, Offset: 0}})
 
 	r.Run("should return an error if the value is a string", func() {
 		// Create a mock expression for the test
 		mockExpr := ast.NewIdentifier("test", tokens.Range{File: "test.sentra", From: tokens.Pos{Line: 1, Column: 1, Offset: 0}, To: tokens.Pos{Line: 1, Column: 1, Offset: 0}})
-		err := validateAgainstBoolTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, "not a bool", typeRef, mockExpr.Span())
+		err := validateAgainstTrinaryTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, "not a bool", typeRef, mockExpr.Span())
 
 		r.Error(err)
 		r.Equal(fmt.Sprintf("value 'not a bool' is not a bool at %s - expected bool", mockExpr.Span()), err.Error())
@@ -37,7 +38,7 @@ func (r *RuntimeTestSuite) TestValidateAgainstBoolTypeRef() {
 	r.Run("should return an error if the value is an int64", func() {
 		// Create a mock expression for the test
 		mockExpr := ast.NewIdentifier("test", tokens.Range{File: "test.sentra", From: tokens.Pos{Line: 1, Column: 1, Offset: 0}, To: tokens.Pos{Line: 1, Column: 1, Offset: 0}})
-		err := validateAgainstBoolTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, int64(123), typeRef, mockExpr.Span())
+		err := validateAgainstTrinaryTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, int64(123), typeRef, mockExpr.Span())
 
 		r.Error(err)
 		r.Equal(fmt.Sprintf("value '123' is not a bool at %s - expected bool", mockExpr.Span()), err.Error())
@@ -46,7 +47,7 @@ func (r *RuntimeTestSuite) TestValidateAgainstBoolTypeRef() {
 	r.Run("should return an error if the value is a float64", func() {
 		// Create a mock expression for the test
 		mockExpr := ast.NewIdentifier("test", tokens.Range{File: "test.sentra", From: tokens.Pos{Line: 1, Column: 1, Offset: 0}, To: tokens.Pos{Line: 1, Column: 1, Offset: 0}})
-		err := validateAgainstBoolTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, float64(123), typeRef, mockExpr.Span())
+		err := validateAgainstTrinaryTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, float64(123), typeRef, mockExpr.Span())
 
 		r.Error(err)
 		r.Equal(fmt.Sprintf("value '123' is not a bool at %s - expected bool", mockExpr.Span()), err.Error())
@@ -55,24 +56,48 @@ func (r *RuntimeTestSuite) TestValidateAgainstBoolTypeRef() {
 	r.Run("should return an error if the value is a string number", func() {
 		// Create a mock expression for the test
 		mockExpr := ast.NewIdentifier("test", tokens.Range{File: "test.sentra", From: tokens.Pos{Line: 1, Column: 1, Offset: 0}, To: tokens.Pos{Line: 1, Column: 1, Offset: 0}})
-		err := validateAgainstBoolTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, "123", typeRef, mockExpr.Span())
+		err := validateAgainstTrinaryTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, "123", typeRef, mockExpr.Span())
 
 		r.Error(err)
 		r.Equal(fmt.Sprintf("value '123' is not a bool at %s - expected bool", mockExpr.Span()), err.Error())
 	})
 
-	r.Run("should not return an error if the value is true", func() {
+	r.Run("should not return an error if the value is boolean true", func() {
 		// Create a mock expression for the test
 		mockExpr := ast.NewIdentifier("test", tokens.Range{File: "test.sentra", From: tokens.Pos{Line: 1, Column: 1, Offset: 0}, To: tokens.Pos{Line: 1, Column: 1, Offset: 0}})
-		err := validateAgainstBoolTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, true, typeRef, mockExpr.Span())
+		err := validateAgainstTrinaryTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, true, typeRef, mockExpr.Span())
 
 		r.NoError(err)
 	})
 
-	r.Run("should not return an error if the value is false", func() {
+	r.Run("should not return an error if the value is boolean false", func() {
 		// Create a mock expression for the test
 		mockExpr := ast.NewIdentifier("test", tokens.Range{File: "test.sentra", From: tokens.Pos{Line: 1, Column: 1, Offset: 0}, To: tokens.Pos{Line: 1, Column: 1, Offset: 0}})
-		err := validateAgainstBoolTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, false, typeRef, mockExpr.Span())
+		err := validateAgainstTrinaryTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, false, typeRef, mockExpr.Span())
+
+		r.NoError(err)
+	})
+
+	r.Run("should not return an error if the value is trinary unknown", func() {
+		// Create a mock expression for the test
+		mockExpr := ast.NewIdentifier("test", tokens.Range{File: "test.sentra", From: tokens.Pos{Line: 1, Column: 1, Offset: 0}, To: tokens.Pos{Line: 1, Column: 1, Offset: 0}})
+		err := validateAgainstTrinaryTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, trinary.Unknown, typeRef, mockExpr.Span())
+
+		r.NoError(err)
+	})
+
+	r.Run("should not return an error if the value is trinary true", func() {
+		// Create a mock expression for the test
+		mockExpr := ast.NewIdentifier("test", tokens.Range{File: "test.sentra", From: tokens.Pos{Line: 1, Column: 1, Offset: 0}, To: tokens.Pos{Line: 1, Column: 1, Offset: 0}})
+		err := validateAgainstTrinaryTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, trinary.True, typeRef, mockExpr.Span())
+
+		r.NoError(err)
+	})
+
+	r.Run("should not return an error if the value is trinary false", func() {
+		// Create a mock expression for the test
+		mockExpr := ast.NewIdentifier("test", tokens.Range{File: "test.sentra", From: tokens.Pos{Line: 1, Column: 1, Offset: 0}, To: tokens.Pos{Line: 1, Column: 1, Offset: 0}})
+		err := validateAgainstTrinaryTypeRef(r.T().Context(), &ExecutionContext{}, &executorImpl{}, &index.Policy{}, trinary.False, typeRef, mockExpr.Span())
 
 		r.NoError(err)
 	})

--- a/tokens/token_kind.go
+++ b/tokens/token_kind.go
@@ -77,6 +77,7 @@ const (
 	KeywordString   Kind = "string"
 	KeywordNumber   Kind = "number"
 	KeywordBoolean  Kind = "boolean"
+	KeywordTrinary  Kind = "trinary"
 	KeywordList     Kind = "list"
 	KeywordMap      Kind = "map"
 	KeywordRecord   Kind = "record"
@@ -170,6 +171,7 @@ var keywords = map[string]Kind{
 	"string":   KeywordString,
 	"number":   KeywordNumber,
 	"boolean":  KeywordBoolean,
+	"trinary":  KeywordTrinary,
 	"list":     KeywordList,
 	"map":      KeywordMap,
 	"record":   KeywordRecord,

--- a/trinary/parse.go
+++ b/trinary/parse.go
@@ -1,0 +1,29 @@
+package trinary
+
+import (
+	"slices"
+)
+
+// Parse parses a string into a trinary value.
+// It converts:
+//   - 1, t, T, TRUE, true, True           => True
+//   - 0, f, F, FALSE, false, False        => False
+//   - -1, n, N, UNKNOWN, unknown, Unknown => Unknown
+//
+// Any other value returns Unknown.
+func Parse(s string) Value {
+	trueValues := []string{"1", "t", "T", "TRUE", "true", "True"}
+	falseValues := []string{"0", "f", "F", "FALSE", "false", "False"}
+	unknownValues := []string{"-1", "n", "N", "UNKNOWN", "unknown", "Unknown"}
+
+	if slices.Contains(trueValues, s) {
+		return True
+	}
+	if slices.Contains(falseValues, s) {
+		return False
+	}
+	if slices.Contains(unknownValues, s) {
+		return Unknown
+	}
+	return Unknown
+}


### PR DESCRIPTION
# Trinary Type Reference Support

## Summary

This PR refactors boolean type references to trinary type references, adding support for three-valued logic (True, False, Unknown) throughout the Sentrie type system. This change enables better handling of unknown or indeterminate values in policy evaluation.

## Changes

### Type Reference Refactoring

- **Renamed `BoolTypeRef` to `TrinaryTypeRef`**: The AST now uses `TrinaryTypeRef` instead of `BoolTypeRef` to better reflect the three-valued nature of the type
- **Updated parser**: Both `boolean` and `trinary` keywords now parse to `TrinaryTypeRef`
- **Added trinary parsing**: New `trinary.Parse()` function supports parsing string values to trinary values
- **Updated constraints**: Renamed `BoolConstraintCheckers` to `TrinaryConstraintCheckers` with support for trinary-specific constraints

### Trinary Value Support

The trinary type supports three values:

- **True**: Represents a true/positive value
- **False**: Represents a false/negative value
- **Unknown**: Represents an unknown/indeterminate value

### Trinary Parsing

Added `trinary.Parse()` function that converts string values to trinary values:

- **True values**: `1`, `t`, `T`, `TRUE`, `true`, `True`
- **False values**: `0`, `f`, `F`, `FALSE`, `false`, `False`
- **Unknown values**: `-1`, `n`, `N`, `UNKNOWN`, `unknown`, `Unknown`
- **Default**: Any other value returns `Unknown`

### Constraints

Trinary type references support the following constraints:

- **`not_unknown`**: Ensures the value is not unknown
- **`eq`**: Equality check against a trinary value
- **`neq`**: Inequality check against a trinary value
- **`is_true`**: Ensures the value is true
- **`is_false`**: Ensures the value is false

### Runtime Validation

- Updated `validateAgainstTrinaryTypeRef()` to handle trinary values
- Boolean values are automatically converted to trinary using `trinary.From()`
- Type validation ensures values are trinary before constraint checking

## Implementation Details

### AST Changes

```go
type TrinaryTypeRef struct {
    *baseTypeRef
}
```

The `TrinaryTypeRef` replaces the previous `BoolTypeRef` and uses the same constraint validation mechanism.

### Parser Changes

The parser now recognizes both `boolean` and `trinary` keywords:

```go
case tokens.KeywordBoolean, tokens.KeywordTrinary:
    ref = ast.NewTrinaryTypeRef(p.advance().Range)
```

### Constraint System

Constraints are defined in `constraints/trinary.go`:

```go
var TrinaryConstraintCheckers map[string]ConstraintDefinition[trinary.Value] = map[string]ConstraintDefinition[trinary.Value]{
    "not_unknown": { /* ... */ },
    "eq": { /* ... */ },
    "neq": { /* ... */ },
    "is_true": { /* ... */ },
    "is_false": { /* ... */ },
}
```

## Example Usage

### In `.sentrie` files:

```sentrie
namespace com/example

shape User {
  isActive: trinary
}

policy user {
  fact user!: User

  rule check = default false {
    yield user.isActive is_true
  }

  export decision of check
}
```

### With constraints:

```sentrie
namespace com/example

shape User {
  status: trinary @not_unknown() -- this is effectively a boolean
}

policy user {
  fact user!: User

  rule validate = default false {
    yield user.status is_true
  }

  export decision of validate
}
```

## Files Changed

- **AST**: `ast/typeref_trinary.go` - New trinary type reference implementation
- **Constraints**: `constraints/trinary.go` - Trinary constraint checkers
- **Parser**: `parser/typeref.go` - Updated to parse both `boolean` and `trinary` keywords
- **Runtime**: `runtime/typeref_trinary.go` - Runtime validation for trinary type references
- **Trinary Package**: `trinary/parse.go` - String parsing for trinary values
- **Tokens**: `tokens/token_kind.go` - Added `KeywordTrinary` token
- **Tests**: `runtime/typeref_trinary_test.go` - Comprehensive tests for trinary type references
- **Example**: `example_pack/minimal.sentrie` - Updated example to use trinary

## Testing

- All trinary parsing tests pass
- Type reference validation tests updated
- Constraint checking tests for trinary values
- Runtime validation tests for trinary type references

## Migration Notes

- The `boolean` keyword is still supported and parses to `TrinaryTypeRef` for backward compatibility
- Boolean values are automatically converted to trinary values (true → True, false → False)
- Existing boolean constraints continue to work with the new trinary type system
