### PR TITLE
Add pipeline operator (`|>`) and `#` call placeholders. Closes #76

### DIFF
--- a/.cursor/plans/issue_76_pipeline_hole_syntax_74c97292.plan.md
+++ b/.cursor/plans/issue_76_pipeline_hole_syntax_74c97292.plan.md
@@ -1,0 +1,119 @@
+---
+name: Pipeline hole syntax
+overview: Add `#` as a pipeline placeholder so the piped value can fill a non-first parameter (e.g. string replace). When `#` is absent, keep today’s behavior (prepend as first argument). Discourage nested inner-call holes in favor of chaining. Lexer + AST + parser substitution, tests, docs; reject stray `#` at eval.
+todos:
+  - id: lex-token
+    content: Add TokenPipelineHole + lexer `case '#'` + lexer tests
+    status: completed
+  - id: ast-hole
+    content: Add PipelineHoleExpression AST + interface test hookup
+    status: completed
+  - id: parse-prefix
+    content: Register prefix parser for hole token
+    status: completed
+  - id: pipeline-subst
+    content: Implement hole detection/substitution in parsePipelineExpression (CallExpression branch); recurse within each top-level argument subtree where needed; preserve memoization
+    status: completed
+  - id: eval-guard
+    content: "eval.go: error on stray PipelineHoleExpression"
+    status: completed
+  - id: tests-cover
+    content: Extend pipeline tests + run coverage on lexer/parser
+    status: completed
+  - id: docs-website
+    content: Update function-chaining.md (and PR description files)
+    status: completed
+isProject: false
+---
+
+# Pipeline placeholder (`#`) for function chaining
+
+## Motivation (primary)
+
+Pipelines already read well when the piped value is the **first** argument. The hole exists for APIs where the “natural” pipeline value belongs **elsewhere**—for example the needle in a replace call:
+
+```sentrie
+let replaceChar = "..."
+replaceChar |> str.replace(input, #, "$$")
+```
+
+That lowers to `str.replace(input, replaceChar, "$$")`. Without `#`, today’s desugaring would only allow prepending (`str.replace(replaceChar, input, ...)`), which is the wrong argument order.
+
+**Style:** Prefer **chaining** when the data flow is “apply g, then f” (`x |> g |> f`). Patterns like `x |> f(g(#))` are **discouraged**: they are usually *less* readable than pushing the inner step into its own `|>` step. The implementation may still substitute `#` inside nested expression trees for correctness (or for rare cases), but docs and examples should **not** present nested inner calls as idiomatic.
+
+## Semantics (agreed)
+
+- **RHS is a call** on an identifier or module-qualified field access (unchanged from [parser/pipeline.go](parser/pipeline.go)).
+- **No `#` in the argument list**: same as today — prepend the left-hand expression as the **first** argument (`x |> f()` → `f(x)`; `x |> f(1)` → `f(x, 1)`).
+- **One or more `#` in the argument list**: **do not** prepend. Recursively replace every `#` with the piped value within the RHS call’s **argument** subtrees (so a hole can appear in any argument position, including inside a top-level ternary/list if it ever appears there). **Hero example:** `needle |> str.replace(haystack, #, repl)` → `str.replace(haystack, needle, repl)`.
+- **Placeholder token**: **`#`** as a new dedicated token (avoids overloading `%` / modulo). Document clearly; modulo stays `a % b` unchanged.
+
+## Implementation (sentrie repo)
+
+### 1. Lexer and tokens
+
+- Add `TokenPipelineHole` (name TBD; e.g. `PipelineHole`) in [tokens/token_kind.go](tokens/token_kind.go).
+- In [lexer/lexer.go](lexer/lexer.go), add `case '#':` that emits the new token (single rune, same pattern as `@`).
+- Tests in [lexer/lexer_test.go](lexer/lexer_test.go): `#` alone, `#` inside `f(a, #, b)`, commas, adjacent tokens.
+
+### 2. AST
+
+- New node `PipelineHoleExpression` (new file under `ast/`, e.g. `ast/pipeline_hole.go`) implementing `Expression`: `Span`, `String()` as `#`, `Kind()`, `expressionNode()`.
+- Extend [ast/node_test.go](ast/node_test.go) (or equivalent) so the expression interface coverage includes the new type.
+
+### 3. Parser
+
+- Register **prefix** parser for `TokenPipelineHole` in [parser/lookups.go](parser/lookups.go) (e.g. `parsePipelineHoleExpression`).
+- **Pipeline lowering** in [parser/pipeline.go](parser/pipeline.go) for `*ast.CallExpression`:
+  - Detect whether any argument subtree contains `*ast.PipelineHoleExpression`.
+  - If **yes**: build new arguments with `substitutePipelineHoles(expr, left)`; **do not** prepend `left`.
+  - If **no**: keep current `append(left, rhs.Arguments...)`.
+  - Re-apply `applyPipelineMemoizationSuffix` on the final call as today.
+- Implement `substitutePipelineHoles` with an exhaustive `switch` over expression types that can embed sub-expressions (calls, lists, maps, ternary, unary, infix, field/index access, cast, etc.). Do **not** substitute into the **callee** of the pipeline RHS call. Nested `f(g(#))` remains *technically* substitutable but is **not** a recommended pattern in documentation.
+
+### 4. Stray `#` outside pipelines
+
+- Pipelines eliminate holes during lowering; if a hole survives (e.g. `let x = #`), evaluation should fail clearly.
+- Add `case *ast.PipelineHoleExpression` in [runtime/eval.go](runtime/eval.go) returning a descriptive error.
+
+### 5. Tests
+
+- [parser/pipeline_test.go](parser/pipeline_test.go): focus table on **non-first** placement and real-world-shaped callees, e.g.:
+  - `x |> f(1, #)` → `f(1, x)`; `x |> f(#, 2)` → `f(x, 2)`.
+  - **Motivating:** `needle |> str.replace(haystack, #, "$$")` (or equivalent module-qualified names used in tests) → `str.replace(haystack, needle, "$$")`.
+  - `x |> f(#)` ≡ `f(x)` (explicit first slot; same as prepend but with `#`).
+  - Mixed chain: `x |> f(1, #) |> g(#)` → `g(f(1, x))`.
+  - Multiple holes in **flat** args: `x |> f(#, #)` → `f(x, x)` if we support it; document both refer to the piped value.
+  - Memoization suffix still applies after lowering.
+- **Do not** center tests on `x |> f(g(#))`; at most one edge-case test if recursion is required for coverage, with a comment that style prefers `x |> g |> f`.
+- Negative: `#` in invalid pipeline RHS still rejected by existing pipeline target rules.
+- Optional runtime test: expression containing only `#` errors in eval.
+
+### 6. Coverage
+
+- Keep **≥90%** coverage on new/changed lexer/parser paths (project norm from issue #76 work); run `go test` with cover for `lexer` and `parser` packages.
+
+### 7. Documentation (website repo)
+
+- Update [website/src/content/docs/reference/function-chaining.md](website/src/content/docs/reference/function-chaining.md):
+  - Lead with **non-first argument** motivation and a `str.replace`-style example.
+  - Explain “omit `#` → value becomes first argument” (current behavior).
+  - Add a short **Multiple holes** note with one example (for completeness): `x |> f(#, #)` → `f(x, x)`, and explicitly say all `#` placeholders bind to the same piped value.
+  - Add a dedicated **Style** subsection (heading-level, not a single bullet) that states clearly:
+    - Prefer **straight chaining** when the data flow is “apply one function, then another”: e.g. `x |> g |> f` rather than folding the same logic into `x |> f(g(#))`.
+    - Use **`#`** when the piped value must appear in a **non-first** parameter (the motivating replace-style case); that is what holes are for, not nesting inner calls for readability.
+    - Nested inner-call holes may be supported by the parser for edge cases, but treat **`x |> outer(inner(#))`** as a **discouraged** pattern when **`x |> inner |> outer`** expresses the same flow more clearly.
+  - Note modulo `%` is unrelated to `#`.
+- [website/src/content/docs/reference/precedence.md](website/src/content/docs/reference/precedence.md): optional one-line mention only if useful.
+
+### 8. PR housekeeping
+
+- **sentrie**: update branch `PR_DESCRIPTION_<branch>.md` per [AGENTS.md](AGENTS.md) (issue number / scope).
+- **website**: update local `PR_DESCRIPTION.md` (even if gitignored, per website AGENTS.md).
+
+## Non-goals (keep scope tight)
+
+- No `%` spelling in v1 unless explicitly expanded later.
+- No changes to ordinary call parsing beyond what’s required for `#` as a primary expression.
+- No runtime semantic for `#` other than parser lowering + eval error if it leaks.
+- Documentation should not promote nested inner-call holes as idiomatic, even if the parser allows them.

--- a/.cursor/plans/issue_76_pipeline_operator_plan_b67aacee.plan.md
+++ b/.cursor/plans/issue_76_pipeline_operator_plan_b67aacee.plan.md
@@ -1,0 +1,135 @@
+---
+name: Issue 76 Pipeline Operator Plan
+overview: Implement `|>` as parser-level desugaring into ordinary call expressions, with exhaustive lexer/parser coverage and semantic regression checks so `use` behavior remains unchanged.
+todos:
+  - id: token-lexer
+    content: Add TokenPipeForward and lexer handling for `|>` plus bare `|` errors
+    status: completed
+  - id: parser-plumbing
+    content: Add pipeline precedence and infix handler registration
+    status: completed
+  - id: pipeline-parser
+    content: Implement parsePipelineExpression with desugaring, validation, metadata preservation, and spans
+    status: completed
+  - id: pipeline-tests
+    content: Add exhaustive lexer/parser positive and negative tests, including precedence and memoization cases
+    status: completed
+  - id: use-semantics-regression
+    content: Add semantic regression test proving `use` behavior is unchanged for bare imported names in pipelines
+    status: completed
+  - id: coverage-gate
+    content: Run package coverage and verify >=90% coverage for all new code
+    status: completed
+  - id: docs-exhaustive
+    content: Update website documentation exhaustively for pipeline syntax, semantics, boundaries, and migration guidance
+    status: completed
+  - id: pr-description
+    content: Update PR_DESCRIPTION_<branch_name>.md with issue-76-only summary and testing notes
+    status: completed
+  - id: pipeline-memoization-extension
+    content: Extend pipeline parsing/desugaring to support memoization on identifier/field-access RHS targets and add matching tests
+    status: completed
+  - id: memoization-suffix-refactor
+    content: Add shared parseMemoizationSuffix helper and wire it into parser/call.go and parser/pipeline.go
+    status: completed
+isProject: false
+---
+
+# Issue 76: Pipeline Operator (`|>`) Implementation Plan
+
+## Scope and constraints
+- Add `|>` as syntax sugar only; runtime evaluation remains unchanged.
+- Keep `use` alias semantics unchanged (no local symbol injection).
+- Reject bare `|` at lexing time.
+- Do not modify ordinary call parsing in [parser/call.go](parser/call.go).
+- Support memoization for pipeline targets consistently, including identifier/field-access targets (not only pre-existing call-expression RHS forms).
+- Require at least 90% coverage for all newly added lexer/parser code paths.
+
+## Implementation steps
+### 1) Token and lexer support
+- Add `TokenPipeForward` to [tokens/token_kind.go](tokens/token_kind.go).
+- Update [lexer/lexer.go](lexer/lexer.go) to:
+  - emit `TokenPipeForward` for `|>`
+  - emit a lexer `Error` token for bare `|` (including EOF/trailing forms).
+
+### 2) Pratt precedence and infix registration
+- Add a dedicated pipeline precedence in [parser/precedence.go](parser/precedence.go) just above `LOWEST` and below ternary/logical/arithmetic levels.
+- Map `TokenPipeForward` to that precedence.
+- Register a new infix handler in [parser/lookups.go](parser/lookups.go): `TokenPipeForward -> parsePipelineExpression`.
+
+### 3) Pipeline desugaring parser
+- Add [parser/pipeline.go](parser/pipeline.go) with `parsePipelineExpression` that:
+  - consumes `|>`
+  - parses RHS using pipeline precedence
+  - validates RHS forms:
+    - `*ast.Identifier`
+    - `*ast.FieldAccessExpression`
+    - `*ast.CallExpression` whose callee is identifier or field-access
+  - lowers to `ast.NewCallExpression` by prepending LHS as argument 0
+  - preserves `Memoized` and `MemoizeTTL` when RHS is already a call
+  - supports memoization syntax on non-call RHS targets as well (e.g., `lhs |> ident!` and `lhs |> alias.fn!30`) by constructing memoized `ast.CallExpression` nodes with matching TTL semantics
+  - sets a stable combined span from LHS start through RHS end
+  - emits a clear parser error for invalid RHS shapes.
+- Do not modify [parser/call.go](parser/call.go) call parsing behavior.
+
+### 3.1) Shared memoization suffix parser refactor
+- Add a shared parser helper (for example in a dedicated parser utility file) named `parseMemoizationSuffix`.
+- Helper contract:
+  - returns `nil` when no `!` suffix is present
+  - returns a struct payload when `!` is present, containing optional `*time.Duration` TTL (`nil` TTL means default memoization behavior)
+- Use this helper in both:
+  - [parser/call.go](parser/call.go) (replace inline `!`/TTL parsing)
+  - [parser/pipeline.go](parser/pipeline.go) (replace duplicated pipeline memoization suffix parsing)
+- Keep parsing semantics unchanged (`!` and optional integer TTL in seconds), while reducing duplication and keeping span updates correct in each caller.
+
+### 4) Exhaustive tests (from test-writer + gap fixes)
+- **Lexer tests** in [lexer/lexer_test.go](lexer/lexer_test.go):
+  - `|>` tokenization with/without spaces (`a|>b`)
+  - multiline pipeline tokenization
+  - bare `|`, trailing `|`, and malformed variants (`||`, `|>>`) produce errors.
+- **Parser lowering and precedence tests** across [parser/precedence_test.go](parser/precedence_test.go), [parser/expression_test.go](parser/expression_test.go), and [parser/error_test.go](parser/error_test.go):
+  - `value |> len` -> `len(value)`
+  - `value |> string.trim` -> `string.trim(value)`
+  - `value |> string.replaceAll(" ", "-")` -> `string.replaceAll(value, " ", "-")`
+  - chaining: `value |> len |> math.abs` -> `math.abs(len(value))`
+  - mixed chaining: `value |> string.trim |> len` -> `len(string.trim(value))`
+  - low precedence: `a + b |> len`, `a ? b : c |> len`
+  - invalid RHS forms rejected with pipeline-specific errors where the RHS callable root is not an identifier or module-qualified field access (e.g., grouped, infix, ternary, list, map, index, or field-access expressions whose root is not an identifier).
+- **Memoization metadata preservation** tests:
+  - first confirm memoization call syntax against existing parser/runtime tests before adding new pipeline cases (so examples match current grammar exactly).
+  - `x |> f!`
+  - `x |> f!10`
+  - `x |> mod.f!30`
+  - `x |> f()!`
+  - `x |> f()!10`
+  - field-qualified call variants preserving TTL and memoized flags.
+- **Semantic regression for `use` behavior**:
+  - parser accepts `value |> trim` syntactically because `Identifier` is an allowed RHS form; this parse-time acceptance must not imply resolution-time success.
+  - add policy/runtime-level regression test (existing suite in parser/index/runtime as appropriate) proving `use { trim } from @sentrie/string` does not make bare `trim(...)` resolvable unless already resolvable under current rules.
+
+### 5) Coverage and validation gate
+- Run targeted coverage for changed packages:
+  - default path: `go test ./lexer ./parser -coverpkg=./lexer,./parser,./tokens -coverprofile=pipeline.cover.out`
+  - if semantic regression lands in runtime tests, expand to include runtime package in the same run.
+  - `go tool cover -func=pipeline.cover.out`
+- Ensure newly introduced code paths (lexer pipe branch + `parsePipelineExpression` branches) are >=90% covered.
+
+### 6) Exhaustive documentation update
+- Update user-facing docs in the website repository comprehensively, including:
+  - language-level syntax and desugaring rules (`lhs |> ident`, `lhs |> alias.fn`, call variants with prepended first arg)
+  - operator precedence and associativity expectations, including mixed chain examples (`value |> string.trim |> len`)
+  - validity boundaries for RHS callable targets (allowed and rejected forms with concrete examples)
+  - explicit parse-time vs resolution-time behavior for identifiers (`value |> trim` may parse but still fail resolution if unresolved)
+  - `use` interaction constraints (no implicit local symbol injection)
+  - multiline formatting and no-whitespace examples (`a|>b`) for readability and lexer behavior expectations
+  - a short troubleshooting section for common parser errors around invalid RHS shapes or bare `|`.
+- Ensure all relevant docs pages are aligned (getting started, language/reference, and CLI docs where expression examples appear) so the feature is discoverable and consistent.
+
+### 7) Branch PR description update
+- Update branch PR description file in repo root per repo convention (`PR_DESCRIPTION_<branch_name>.md`) to summarize only issue #76 changes, testing, reviewer focus areas, and docs updates.
+
+## Reviewer focus points
+- Pipeline precedence placement and associativity correctness.
+- RHS shape validation boundaries (no accidental broadening).
+- Memoization metadata preservation during desugaring.
+- No semantic drift in `use` name resolution.

--- a/.cursor/rules/copyright-year-on-touch.mdc
+++ b/.cursor/rules/copyright-year-on-touch.mdc
@@ -1,5 +1,5 @@
 ---
-description: New licensed files use SPDX-FileCopyrightText (© + year + git user.name / optional user.email) and SPDX-License-Identifier; do not change existing headers on ordinary edits.
+description: Maintain license headers for touched source files only: add missing headers when required and update outdated copyright years.
 alwaysApply: true
 ---
 
@@ -32,12 +32,26 @@ If Git identity is **not** available or the repo standard differs (e.g. corporat
 - Prefer the **actual current year** for the session: use **`Today's date`** from the user or workspace context when it is provided (authoritative for the run).
 - If no date is available, use a **reasonable default** for “now” (do **not** assume a fixed past year such as 2025).
 
-## Existing files
+## Source-file scope
 
-When you **modify** a file that **already** has a license header (including **`SPDX-FileCopyrightText`**, legacy **`Copyright …`** lines, or the full Apache boilerplate block), **leave the copyright year and header text unchanged** unless the user **explicitly** asks to refresh, migrate, or correct it.
+This rule applies **only** when editing a **source file**. In this repository, source-file extensions are:
+`.go`, `.ts`, `.js`, `.sentrie`, `.sh`, `.ps1`, `.peg`, `.ebnf`.
 
-Do **not** run drive-by or mass copyright-year updates on files you did not touch, unless the user **explicitly** asks for that.
+Follow repository conventions if additional extensions are treated as source in this repo.
+
+Do **not** apply this rule to non-source files (for example `.md`, `.txt`, `.json`, `.yaml`, `.yml`, lockfiles, generated assets), unless the user explicitly asks.
+
+## Existing touched source files
+
+When you modify a touched source file that already has a license header (including `SPDX-FileCopyrightText`, legacy `Copyright ...` lines, or the full Apache boilerplate block):
+
+- You **MUST** update an outdated copyright year to the current year for this session.
+- You **MUST NOT** change untouched files only to refresh headers.
+- You **MUST NOT** run repository-wide header refreshes unless explicitly requested.
 
 ## Legacy headers
 
-Older files may use only `SPDX-License-Identifier` plus a `Copyright …` paragraph and Apache license text. **Do not rewrite those to the two-line form** as part of unrelated edits; only new files (or explicit migration tasks) should use the **`SPDX-FileCopyrightText`** + **`SPDX-License-Identifier`** pattern above.
+Older files may use only `SPDX-License-Identifier` plus a `Copyright ...` paragraph and Apache license text.
+
+- If such a header exists in a touched source file, keep the header style, but update an outdated year.
+- Do **not** rewrite legacy headers to the two-line form as part of unrelated edits; only new files (or explicit migration tasks) should use the `SPDX-FileCopyrightText` + `SPDX-License-Identifier` pattern above.

--- a/ast/node_test.go
+++ b/ast/node_test.go
@@ -108,6 +108,12 @@ func (s *AstTestSuite) TestExpressionInterface() {
 	str := NewStringLiteral("hello", r)
 	s.Implements((*Expression)(nil), str)
 	s.Implements((*Node)(nil), str)
+
+	// Test PipelineHoleExpression implements Expression
+	hole := NewPipelineHoleExpression(r)
+	s.Implements((*Expression)(nil), hole)
+	s.Implements((*Node)(nil), hole)
+	s.Equal("#", hole.String())
 }
 
 // TestNodePositioning tests position handling across different node types

--- a/ast/node_test.go
+++ b/ast/node_test.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package ast
 

--- a/ast/pipeline_hole.go
+++ b/ast/pipeline_hole.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package ast
+
+import "github.com/sentrie-sh/sentrie/tokens"
+
+// PipelineHoleExpression is a placeholder used by pipeline lowering.
+type PipelineHoleExpression struct {
+	*baseNode
+}
+
+func NewPipelineHoleExpression(ssp tokens.Range) *PipelineHoleExpression {
+	return &PipelineHoleExpression{
+		baseNode: &baseNode{
+			Rnge:  ssp,
+			Kind_: "pipeline_hole",
+		},
+	}
+}
+
+func (p *PipelineHoleExpression) String() string {
+	return "#"
+}
+
+func (p *PipelineHoleExpression) expressionNode() {}
+
+var _ Expression = &PipelineHoleExpression{}
+var _ Node = &PipelineHoleExpression{}

--- a/example_pack/minimal.sentrie
+++ b/example_pack/minimal.sentrie
@@ -58,17 +58,17 @@ policy var_test {
   let numbers: list[number] = [1, 2, 3, 4, 5]
   let words: list[string] = ["Hello", "World", "Sentrie"]
   
-  let sum: number = reduce numbers from 0 as acc, num, idx {
+  let sum: number = reduce(numbers, 0, (acc, num, idx) => {
     yield acc + num
-  }
+  })
   
-  let max: number = reduce numbers from numbers[0] as acc, num, idx {
+  let max: number = reduce(numbers, numbers[0], (acc, num, idx) => {
     yield num > acc ? num : acc
-  }
+  })
   
-  let min: number = reduce numbers from numbers[0] as acc, num, idx {
+  let min: number = reduce(numbers, numbers[0], (acc, num, idx) => {
     yield num < acc ? num : acc
-  }
+  })
   
   let tri:trinary = unknown
 

--- a/example_pack/pipeline_basics.sentrie
+++ b/example_pack/pipeline_basics.sentrie
@@ -4,7 +4,7 @@ policy basics {
   fact input?: string as input default "  Hello World  "
 
   rule has_content = default false {
-    let chars = input |> count
+    let chars = input |> count()
     yield chars > 0
   }
 

--- a/example_pack/pipeline_basics.sentrie
+++ b/example_pack/pipeline_basics.sentrie
@@ -1,0 +1,12 @@
+namespace sh/sentrie/example/pipeline
+
+policy basics {
+  fact input?: string as input default "  Hello World  "
+
+  rule has_content = default false {
+    let chars = input |> count
+    yield chars > 0
+  }
+
+  export decision of has_content
+}

--- a/example_pack/pipeline_memoized_calls.sentrie
+++ b/example_pack/pipeline_memoized_calls.sentrie
@@ -8,7 +8,7 @@ policy memoized_pipeline {
   rule digest_length_memoized = default 0 {
     let length = input
       |> hash.sha256()!60
-      |> count!30
+      |> count()!30
 
     yield length
   }

--- a/example_pack/pipeline_memoized_calls.sentrie
+++ b/example_pack/pipeline_memoized_calls.sentrie
@@ -1,0 +1,17 @@
+namespace sh/sentrie/example/pipeline/memoized
+
+policy memoized_pipeline {
+  fact input?: string as input default "memoized-input"
+
+  use { sha256 } from @sentrie/hash as hash
+
+  rule digest_length_memoized = default 0 {
+    let length = input
+      |> hash.sha256()!60
+      |> count!30
+
+    yield length
+  }
+
+  export decision of digest_length_memoized
+}

--- a/example_pack/pipeline_module_calls.sentrie
+++ b/example_pack/pipeline_module_calls.sentrie
@@ -1,0 +1,22 @@
+namespace sh/sentrie/example/pipeline/module
+
+policy module_pipeline {
+  fact input?: string as input default "sentrie"
+
+  use { sha256 } from @sentrie/hash as hash
+
+  rule digest_available = default false {
+    let digest = input |> hash.sha256
+    yield digest != ""
+  }
+
+  rule digest_length = default 0 {
+    let length = input
+                  |> hash.sha256
+                  |> count
+    yield length
+  }
+
+  export decision of digest_available
+  export decision of digest_length
+}

--- a/example_pack/pipeline_module_calls.sentrie
+++ b/example_pack/pipeline_module_calls.sentrie
@@ -6,14 +6,14 @@ policy module_pipeline {
   use { sha256 } from @sentrie/hash as hash
 
   rule digest_available = default false {
-    let digest = input |> hash.sha256
+    let digest = input |> hash.sha256()
     yield digest != ""
   }
 
   rule digest_length = default 0 {
     let length = input
-                  |> hash.sha256
-                  |> count
+                  |> hash.sha256()
+                  |> count()
     yield length
   }
 

--- a/example_pack/pipeline_placeholder.sentrie
+++ b/example_pack/pipeline_placeholder.sentrie
@@ -1,0 +1,21 @@
+namespace sh/sentrie/example/pipeline/placeholder
+
+policy placeholder_pipeline {
+  fact input?: string as input default "hello world"
+  fact needle?: string as needle default "world"
+
+  use { replaceAll } from @sentrie/js as str
+
+  rule replaced = default "" {
+    let out = needle |> str.replaceAll(input, #, "sentrie")
+    yield out
+  }
+
+  rule duplicated = default "" {
+    let out = needle |> str.replaceAll(#, #, "x")
+    yield out
+  }
+
+  export decision of replaced
+  export decision of duplicated
+}

--- a/example_pack/sentrie.pack.toml
+++ b/example_pack/sentrie.pack.toml
@@ -1,20 +1,27 @@
-schema_version = "0.1.0"
-name = "example"
-# version = "0.1.0"
-# description = "Example pack"
-# license = "MIT"
-# repository = "https://github.com/binaek/sentrie"
-# 
-# [engines]
-# sentrie = "0.1.0"
-# 
-# [authors]
-# "Binaek Sarkar" = "binaek@gmail.com"
-# 
-# [permissions]
-# fs_read = ["/etc/passwd"]
-# net = ["http://example.com"]
-# 
-# [metadata]
-# permissions = { fs_read = ["/etc/passwd"], net = ["http://example.com"] }
-# metadata = { "example" = "example" }
+[schema]
+version = 1
+
+[pack]
+name = "example-pack"
+version = "1.2.3"
+description = "Organization policies across all teams"
+license = "MIT"
+repository = "https://github.com/my-org/org-policies"
+
+[pack.authors]
+"John Doe" = "john@example.com"
+"Alice Robinson" = "alice@example.com"
+"Bob Smith" = "bob@example.com"
+
+[engine]
+sentrie = ">=0.1.0 <2.0.0"
+
+[permissions]
+fs_read = ["./data/**", "/etc/ssl/certs/**"]
+net = ["https://api.example.com", "https://sts.amazonaws.com"]
+env = ["AWS_REGION", "AWS_PROFILE"]
+
+[metadata]
+category = "enterprise"
+maturity = "stable"
+team = "platform"

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -194,6 +194,10 @@ func (l *Lexer) NextToken() tokens.Instance {
 			l.readRune()
 			endPos := l.currentPosition()
 			return tokens.New(tokens.TokenAt, "@", tokens.NewRange(l.filename, startPos, endPos))
+		case '#':
+			l.readRune()
+			endPos := l.currentPosition()
+			return tokens.New(tokens.TokenPipelineHole, "#", tokens.NewRange(l.filename, startPos, endPos))
 		case '|':
 			if l.peekAhead() == '>' {
 				l.readRune()

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package lexer
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -194,6 +194,16 @@ func (l *Lexer) NextToken() tokens.Instance {
 			l.readRune()
 			endPos := l.currentPosition()
 			return tokens.New(tokens.TokenAt, "@", tokens.NewRange(l.filename, startPos, endPos))
+		case '|':
+			if l.peekAhead() == '>' {
+				l.readRune()
+				endPos := l.currentPosition()
+				l.readRune()
+				return tokens.New(tokens.TokenPipeForward, "|>", tokens.NewRange(l.filename, startPos, endPos))
+			}
+			l.readRune()
+			endPos := l.currentPosition()
+			return tokens.New(tokens.Error, "unexpected '|': only '|>' is supported", tokens.NewRange(l.filename, startPos, endPos))
 		case ',':
 			l.readRune()
 			endPos := l.currentPosition()

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -1,6 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2026 Binaek Sarkar
 
 package lexer
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -125,3 +125,39 @@ func TestLexerRejectsDoublePipe(t *testing.T) {
 		t.Fatalf("expected error token, got %s", tok.Kind)
 	}
 }
+
+func TestLexerPipelineHoleToken(t *testing.T) {
+	got := collectKinds("#")
+	want := []tokens.Kind{tokens.TokenPipelineHole, tokens.EOF}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d tokens, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("token %d: expected %s, got %s", i, want[i], got[i])
+		}
+	}
+}
+
+func TestLexerPipelineHoleInsideCall(t *testing.T) {
+	got := collectKinds("f(a, #, b)")
+	want := []tokens.Kind{
+		tokens.Ident,
+		tokens.PunctLeftParentheses,
+		tokens.Ident,
+		tokens.PunctComma,
+		tokens.TokenPipelineHole,
+		tokens.PunctComma,
+		tokens.Ident,
+		tokens.PunctRightParentheses,
+		tokens.EOF,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d tokens, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("token %d: expected %s, got %s", i, want[i], got[i])
+		}
+	}
+}

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -11,6 +11,25 @@ import (
 	"github.com/sentrie-sh/sentrie/tokens"
 )
 
+func collectKinds(input string) []tokens.Kind {
+	l := NewLexer(strings.NewReader(input), "test.sent")
+	kinds := []tokens.Kind{}
+	for {
+		tok := l.NextToken()
+		kinds = append(kinds, tok.Kind)
+		if tok.Kind == tokens.EOF || tok.Kind == tokens.Error {
+			break
+		}
+	}
+	return kinds
+}
+
+func mustNextToken(t *testing.T, l *Lexer) tokens.Instance {
+	t.Helper()
+	tok := l.NextToken()
+	return tok
+}
+
 func TestLexerHereDocRejectsInvalidTagStart(t *testing.T) {
 	l := NewLexer(strings.NewReader("<<<1TAG\nbody\nTAG\n"), "test.sent")
 
@@ -20,5 +39,89 @@ func TestLexerHereDocRejectsInvalidTagStart(t *testing.T) {
 	}
 	if !strings.Contains(tok.Value, "heredoc requires identifier tag") {
 		t.Fatalf("unexpected literal: %q", tok.Value)
+	}
+}
+
+func TestLexerPipelineToken(t *testing.T) {
+	l := NewLexer(strings.NewReader("value |> len"), "test.sent")
+
+	tok := mustNextToken(t, l)
+	if tok.Kind != tokens.Ident || tok.Value != "value" {
+		t.Fatalf("expected first ident token, got %s(%q)", tok.Kind, tok.Value)
+	}
+
+	tok = mustNextToken(t, l)
+	if tok.Kind != tokens.TokenPipeForward || tok.Value != "|>" {
+		t.Fatalf("expected pipeline token, got %s(%q)", tok.Kind, tok.Value)
+	}
+
+	tok = mustNextToken(t, l)
+	if tok.Kind != tokens.Ident || tok.Value != "len" {
+		t.Fatalf("expected rhs ident token, got %s(%q)", tok.Kind, tok.Value)
+	}
+}
+
+func TestLexerPipelineNoWhitespace(t *testing.T) {
+	got := collectKinds("a|>b")
+	want := []tokens.Kind{tokens.Ident, tokens.TokenPipeForward, tokens.Ident, tokens.EOF}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d tokens, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("token %d: expected %s, got %s", i, want[i], got[i])
+		}
+	}
+}
+
+func TestLexerPipelineMultilineSequence(t *testing.T) {
+	got := collectKinds("value\n|> string.trim\n|> len")
+	want := []tokens.Kind{
+		tokens.Ident,
+		tokens.TokenPipeForward,
+		tokens.KeywordString,
+		tokens.TokenDot,
+		tokens.Ident,
+		tokens.TokenPipeForward,
+		tokens.Ident,
+		tokens.EOF,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d tokens, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("token %d: expected %s, got %s", i, want[i], got[i])
+		}
+	}
+}
+
+func TestLexerRejectsBarePipe(t *testing.T) {
+	l := NewLexer(strings.NewReader("value | len"), "test.sent")
+	_ = mustNextToken(t, l) // value
+	tok := mustNextToken(t, l)
+	if tok.Kind != tokens.Error {
+		t.Fatalf("expected error token, got %s", tok.Kind)
+	}
+	if !strings.Contains(tok.Value, "only '|>' is supported") {
+		t.Fatalf("expected pipe error message, got %q", tok.Value)
+	}
+}
+
+func TestLexerRejectsTrailingPipeAtEOF(t *testing.T) {
+	l := NewLexer(strings.NewReader("value |"), "test.sent")
+	_ = mustNextToken(t, l) // value
+	tok := mustNextToken(t, l)
+	if tok.Kind != tokens.Error {
+		t.Fatalf("expected error token, got %s", tok.Kind)
+	}
+}
+
+func TestLexerRejectsDoublePipe(t *testing.T) {
+	l := NewLexer(strings.NewReader("value || len"), "test.sent")
+	_ = mustNextToken(t, l) // value
+	tok := mustNextToken(t, l)
+	if tok.Kind != tokens.Error {
+		t.Fatalf("expected error token, got %s", tok.Kind)
 	}
 }

--- a/parser/call.go
+++ b/parser/call.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package parser
 

--- a/parser/call.go
+++ b/parser/call.go
@@ -18,7 +18,6 @@ package parser
 
 import (
 	"context"
-	"time"
 
 	"github.com/sentrie-sh/sentrie/ast"
 	"github.com/sentrie-sh/sentrie/tokens"
@@ -46,25 +45,13 @@ func parseCallExpression(ctx context.Context, p *Parser, left ast.Expression, pr
 
 	exp := ast.NewCallExpression(left, arguments, false, nil, rnge)
 
-	if p.head().IsOfKind(tokens.TokenBang) {
-		bang, found := p.advanceExpected(tokens.TokenBang)
-		if !found {
-			return nil
-		}
-		rnge.To = bang.Range.To
-
+	hadBang := p.head().IsOfKind(tokens.TokenBang)
+	if suffix := parseMemoizationSuffix(ctx, p); suffix != nil {
 		exp.Memoized = true
-		exp.MemoizeTTL = nil
-
-		if p.head().IsOfKind(tokens.Int) {
-			literal := parseIntegerLiteral(ctx, p)
-			if literal == nil {
-				return nil
-			}
-			ttl := time.Duration(literal.(*ast.IntegerLiteral).Value) * time.Second
-			exp.MemoizeTTL = &ttl
-			rnge.To = literal.Span().To
-		}
+		exp.MemoizeTTL = suffix.TTL
+		rnge.To = suffix.To
+	} else if hadBang {
+		return nil
 	}
 
 	return exp

--- a/parser/error_test.go
+++ b/parser/error_test.go
@@ -175,6 +175,8 @@ func (s *ParserTestSuite) TestParseErrorInvalidOperators() {
 		"namespace com/example; rule check { 1 %% 2 }",  // Invalid operator
 		"namespace com/example; rule check { 1 &&& 2 }", // Invalid operator
 		"namespace com/example; rule check { 1 ||| 2 }", // Invalid operator
+
+		"namespace com/example; policy p { rule allow = value | len export decision of allow }", // Bare pipe should fail at lexer level
 	}
 
 	for _, tc := range testCases {

--- a/parser/error_test.go
+++ b/parser/error_test.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package parser
 

--- a/parser/lookups.go
+++ b/parser/lookups.go
@@ -62,6 +62,7 @@ func (p *Parser) registerParseFns() {
 	p.registerInfix(tokens.PunctLeftBracket, parseIndexAccessExpression)
 	p.registerInfix(tokens.TokenDot, parseFieldAccessExpression)
 	p.registerInfix(tokens.PunctLeftParentheses, parseCallExpression)
+	p.registerInfix(tokens.TokenPipeForward, parsePipelineExpression)
 
 	p.registerInfix(tokens.TokenPlus, parseInfixExpression)
 	p.registerInfix(tokens.TokenMinus, parseInfixExpression)

--- a/parser/lookups.go
+++ b/parser/lookups.go
@@ -34,6 +34,7 @@ func (p *Parser) registerParseFns() {
 	p.registerPrefix(tokens.KeywordCast, parseCastExpression)
 
 	p.registerPrefix(tokens.Ident, parseIdentifier)
+	p.registerPrefix(tokens.TokenPipelineHole, parsePipelineHoleExpression)
 	p.registerPrefix(tokens.String, parseStringLiteral)
 	p.registerPrefix(tokens.Int, parseIntegerLiteral)
 	p.registerPrefix(tokens.Float, parseFloatLiteral)

--- a/parser/lookups.go
+++ b/parser/lookups.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package parser
 

--- a/parser/memoization.go
+++ b/parser/memoization.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2026 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package parser
 

--- a/parser/memoization.go
+++ b/parser/memoization.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright 2026 Binaek Sarkar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"context"
+	"time"
+
+	"github.com/sentrie-sh/sentrie/ast"
+	"github.com/sentrie-sh/sentrie/tokens"
+)
+
+type memoizationSuffix struct {
+	TTL *time.Duration
+	To  tokens.Pos
+}
+
+// parseMemoizationSuffix parses a trailing memoization suffix.
+//
+// Returns nil when no suffix is present.
+func parseMemoizationSuffix(ctx context.Context, p *Parser) *memoizationSuffix {
+	if !p.head().IsOfKind(tokens.TokenBang) {
+		return nil
+	}
+	bang, found := p.advanceExpected(tokens.TokenBang)
+	if !found {
+		return nil
+	}
+	suffix := &memoizationSuffix{
+		TTL: nil,
+		To:  bang.Range.To,
+	}
+	if p.head().IsOfKind(tokens.Int) {
+		literal := parseIntegerLiteral(ctx, p)
+		if literal == nil {
+			return nil
+		}
+		ttl := time.Duration(literal.(*ast.IntegerLiteral).Value) * time.Second
+		suffix.TTL = &ttl
+		suffix.To = literal.Span().To
+	}
+	return suffix
+}

--- a/parser/pipeline.go
+++ b/parser/pipeline.go
@@ -57,9 +57,17 @@ func parsePipelineExpression(ctx context.Context, p *Parser, left ast.Expression
 		return applyPipelineMemoizationSuffix(ctx, p, call, pipelineRange)
 	case *ast.CallExpression:
 		if hasIdentifierRoot(rhs.Callee) {
-			args := make([]ast.Expression, 0, len(rhs.Arguments)+1)
-			args = append(args, left)
-			args = append(args, rhs.Arguments...)
+			args := rhs.Arguments
+			if containsPipelineHoleInExprs(rhs.Arguments) {
+				args = make([]ast.Expression, len(rhs.Arguments))
+				for i := range rhs.Arguments {
+					args[i] = substitutePipelineHoles(rhs.Arguments[i], left)
+				}
+			} else {
+				args = make([]ast.Expression, 0, len(rhs.Arguments)+1)
+				args = append(args, left)
+				args = append(args, rhs.Arguments...)
+			}
 			return ast.NewCallExpression(rhs.Callee, args, rhs.Memoized, rhs.MemoizeTTL, pipelineRange)
 		}
 	}
@@ -93,4 +101,122 @@ func applyPipelineMemoizationSuffix(ctx context.Context, p *Parser, call *ast.Ca
 	rnge := baseRange
 	rnge.To = suffix.To
 	return ast.NewCallExpression(call.Callee, call.Arguments, true, suffix.TTL, rnge)
+}
+
+func containsPipelineHoleInExprs(exprs []ast.Expression) bool {
+	for i := range exprs {
+		if containsPipelineHole(exprs[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPipelineHole(expr ast.Expression) bool {
+	switch t := expr.(type) {
+	case *ast.PipelineHoleExpression:
+		return true
+	case *ast.CallExpression:
+		if containsPipelineHole(t.Callee) {
+			return true
+		}
+		return containsPipelineHoleInExprs(t.Arguments)
+	case *ast.FieldAccessExpression:
+		return containsPipelineHole(t.Left)
+	case *ast.IndexAccessExpression:
+		return containsPipelineHole(t.Left) || containsPipelineHole(t.Index)
+	case *ast.ListLiteral:
+		return containsPipelineHoleInExprs(t.Values)
+	case *ast.MapLiteral:
+		for i := range t.Entries {
+			if containsPipelineHole(t.Entries[i].Key) || containsPipelineHole(t.Entries[i].Value) {
+				return true
+			}
+		}
+	case *ast.InfixExpression:
+		return containsPipelineHole(t.Left) || containsPipelineHole(t.Right)
+	case *ast.UnaryExpression:
+		return containsPipelineHole(t.Right)
+	case *ast.TernaryExpression:
+		return containsPipelineHole(t.Condition) || containsPipelineHole(t.ThenBranch) || containsPipelineHole(t.ElseBranch)
+	case *ast.CastExpression:
+		return containsPipelineHole(t.Expr)
+	case *ast.IsDefinedExpression:
+		return containsPipelineHole(t.Left)
+	case *ast.IsEmptyExpression:
+		return containsPipelineHole(t.Left)
+	case *ast.TransformExpression:
+		return containsPipelineHole(t.Argument)
+	case *ast.PrecedingCommentExpression:
+		return containsPipelineHole(t.Wrap)
+	case *ast.TrailingCommentExpression:
+		return containsPipelineHole(t.Wrap)
+	}
+	return false
+}
+
+func substitutePipelineHoles(expr ast.Expression, replacement ast.Expression) ast.Expression {
+	switch t := expr.(type) {
+	case *ast.PipelineHoleExpression:
+		return replacement
+	case *ast.CallExpression:
+		args := make([]ast.Expression, len(t.Arguments))
+		for i := range t.Arguments {
+			args[i] = substitutePipelineHoles(t.Arguments[i], replacement)
+		}
+		return ast.NewCallExpression(substitutePipelineHoles(t.Callee, replacement), args, t.Memoized, t.MemoizeTTL, t.Span())
+	case *ast.FieldAccessExpression:
+		return ast.NewFieldAccessExpression(substitutePipelineHoles(t.Left, replacement), t.Field, t.Span())
+	case *ast.IndexAccessExpression:
+		return ast.NewIndexAccessExpression(
+			substitutePipelineHoles(t.Left, replacement),
+			substitutePipelineHoles(t.Index, replacement),
+			t.Span(),
+		)
+	case *ast.ListLiteral:
+		values := make([]ast.Expression, len(t.Values))
+		for i := range t.Values {
+			values[i] = substitutePipelineHoles(t.Values[i], replacement)
+		}
+		return ast.NewListLiteral(values, t.Span())
+	case *ast.MapLiteral:
+		entries := make([]ast.MapEntry, len(t.Entries))
+		for i := range t.Entries {
+			entries[i] = ast.MapEntry{
+				Key:   substitutePipelineHoles(t.Entries[i].Key, replacement),
+				Value: substitutePipelineHoles(t.Entries[i].Value, replacement),
+			}
+		}
+		return ast.NewMapLiteral(entries, t.Span())
+	case *ast.InfixExpression:
+		return ast.NewInfixExpression(
+			substitutePipelineHoles(t.Left, replacement),
+			substitutePipelineHoles(t.Right, replacement),
+			t.Operator,
+			t.Span(),
+		)
+	case *ast.UnaryExpression:
+		return ast.NewUnaryExpression(t.Operator, substitutePipelineHoles(t.Right, replacement), t.Span())
+	case *ast.TernaryExpression:
+		return ast.NewTernaryExpression(
+			substitutePipelineHoles(t.Condition, replacement),
+			substitutePipelineHoles(t.ThenBranch, replacement),
+			substitutePipelineHoles(t.ElseBranch, replacement),
+			t.Span(),
+		)
+	case *ast.CastExpression:
+		return ast.NewCastExpression(substitutePipelineHoles(t.Expr, replacement), t.TargetType, t.Span())
+	case *ast.IsDefinedExpression:
+		return ast.NewIsDefinedExpression(substitutePipelineHoles(t.Left, replacement), t.Span())
+	case *ast.IsEmptyExpression:
+		return ast.NewIsEmptyExpression(substitutePipelineHoles(t.Left, replacement), t.Span())
+	case *ast.TransformExpression:
+		return ast.NewTransformExpression(substitutePipelineHoles(t.Argument, replacement), t.Transformer, t.Span())
+	case *ast.PrecedingCommentExpression:
+		return ast.NewPrecedingCommentExpression(t.CommentContent, substitutePipelineHoles(t.Wrap, replacement), t.Span())
+	case *ast.TrailingCommentExpression:
+		return ast.NewTrailingCommentExpression(t.CommentContent, substitutePipelineHoles(t.Wrap, replacement), t.Span())
+	default:
+		return expr
+	}
 }

--- a/parser/pipeline.go
+++ b/parser/pipeline.go
@@ -28,6 +28,10 @@ func parsePipelineExpression(ctx context.Context, p *Parser, left ast.Expression
 	if !found {
 		return nil
 	}
+	if left == nil {
+		p.errorf("invalid pipeline target: missing left-hand side expression")
+		return nil
+	}
 
 	startedAsGrouped := p.head().IsOfKind(tokens.PunctLeftParentheses)
 	right := p.parseExpression(ctx, precedence)
@@ -45,37 +49,30 @@ func parsePipelineExpression(ctx context.Context, p *Parser, left ast.Expression
 		To:   right.Span().To,
 	}
 
-	switch rhs := right.(type) {
-	case *ast.Identifier:
-		call := ast.NewCallExpression(rhs, []ast.Expression{left}, false, nil, pipelineRange)
-		return applyPipelineMemoizationSuffix(ctx, p, call, pipelineRange)
-	case *ast.FieldAccessExpression:
-		if !hasIdentifierRoot(rhs) {
-			break
-		}
-		call := ast.NewCallExpression(rhs, []ast.Expression{left}, false, nil, pipelineRange)
-		return applyPipelineMemoizationSuffix(ctx, p, call, pipelineRange)
-	case *ast.CallExpression:
-		if hasIdentifierRoot(rhs.Callee) {
-			args := rhs.Arguments
-			if containsPipelineHoleInExprs(rhs.Arguments) {
-				args = make([]ast.Expression, len(rhs.Arguments))
-				for i := range rhs.Arguments {
-					args[i] = substitutePipelineHoles(rhs.Arguments[i], left)
-				}
-			} else {
-				args = make([]ast.Expression, 0, len(rhs.Arguments)+1)
-				args = append(args, left)
-				args = append(args, rhs.Arguments...)
-			}
-			return ast.NewCallExpression(rhs.Callee, args, rhs.Memoized, rhs.MemoizeTTL, pipelineRange)
-		}
+	const invalidPipelineRHS = "invalid pipeline target: right-hand side must be a call on an identifier or module-qualified field access"
+
+	rhs, ok := right.(*ast.CallExpression)
+	if !ok {
+		p.errorf(invalidPipelineRHS)
+		return nil
+	}
+	if !hasIdentifierRoot(rhs.Callee) {
+		p.errorf(invalidPipelineRHS)
+		return nil
 	}
 
-	p.errorf(
-		"invalid pipeline target: right-hand side must be an identifier, a module-qualified field access, or a call on one of those targets",
-	)
-	return nil
+	var args []ast.Expression
+	if containsPipelineHoleInExprs(rhs.Arguments) {
+		args = make([]ast.Expression, len(rhs.Arguments))
+		for i := range rhs.Arguments {
+			args[i] = substitutePipelineHoles(rhs.Arguments[i], left)
+		}
+	} else {
+		args = make([]ast.Expression, 0, len(rhs.Arguments)+1)
+		args = append(args, left)
+		args = append(args, rhs.Arguments...)
+	}
+	return ast.NewCallExpression(rhs.Callee, args, rhs.Memoized, rhs.MemoizeTTL, pipelineRange)
 }
 
 func hasIdentifierRoot(expr ast.Expression) bool {
@@ -87,20 +84,6 @@ func hasIdentifierRoot(expr ast.Expression) bool {
 	default:
 		return false
 	}
-}
-
-func applyPipelineMemoizationSuffix(ctx context.Context, p *Parser, call *ast.CallExpression, baseRange tokens.Range) ast.Expression {
-	hadBang := p.head().IsOfKind(tokens.TokenBang)
-	suffix := parseMemoizationSuffix(ctx, p)
-	if suffix == nil {
-		if hadBang {
-			return nil
-		}
-		return call
-	}
-	rnge := baseRange
-	rnge.To = suffix.To
-	return ast.NewCallExpression(call.Callee, call.Arguments, true, suffix.TTL, rnge)
 }
 
 func containsPipelineHoleInExprs(exprs []ast.Expression) bool {

--- a/parser/pipeline.go
+++ b/parser/pipeline.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2026 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package parser
 

--- a/parser/pipeline.go
+++ b/parser/pipeline.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright 2026 Binaek Sarkar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"context"
+
+	"github.com/sentrie-sh/sentrie/ast"
+	"github.com/sentrie-sh/sentrie/tokens"
+)
+
+func parsePipelineExpression(ctx context.Context, p *Parser, left ast.Expression, precedence Precedence) ast.Expression {
+	operator, found := p.advanceExpected(tokens.TokenPipeForward)
+	if !found {
+		return nil
+	}
+
+	startedAsGrouped := p.head().IsOfKind(tokens.PunctLeftParentheses)
+	right := p.parseExpression(ctx, precedence)
+	if right == nil {
+		return nil
+	}
+	if startedAsGrouped {
+		p.errorf("invalid pipeline target: grouped expressions are not allowed on the right-hand side")
+		return nil
+	}
+
+	pipelineRange := tokens.Range{
+		File: operator.Range.File,
+		From: left.Span().From,
+		To:   right.Span().To,
+	}
+
+	switch rhs := right.(type) {
+	case *ast.Identifier:
+		call := ast.NewCallExpression(rhs, []ast.Expression{left}, false, nil, pipelineRange)
+		return applyPipelineMemoizationSuffix(ctx, p, call, pipelineRange)
+	case *ast.FieldAccessExpression:
+		if !hasIdentifierRoot(rhs) {
+			break
+		}
+		call := ast.NewCallExpression(rhs, []ast.Expression{left}, false, nil, pipelineRange)
+		return applyPipelineMemoizationSuffix(ctx, p, call, pipelineRange)
+	case *ast.CallExpression:
+		if hasIdentifierRoot(rhs.Callee) {
+			args := make([]ast.Expression, 0, len(rhs.Arguments)+1)
+			args = append(args, left)
+			args = append(args, rhs.Arguments...)
+			return ast.NewCallExpression(rhs.Callee, args, rhs.Memoized, rhs.MemoizeTTL, pipelineRange)
+		}
+	}
+
+	p.errorf(
+		"invalid pipeline target: right-hand side must be an identifier, a module-qualified field access, or a call on one of those targets",
+	)
+	return nil
+}
+
+func hasIdentifierRoot(expr ast.Expression) bool {
+	switch t := expr.(type) {
+	case *ast.Identifier:
+		return true
+	case *ast.FieldAccessExpression:
+		return hasIdentifierRoot(t.Left)
+	default:
+		return false
+	}
+}
+
+func applyPipelineMemoizationSuffix(ctx context.Context, p *Parser, call *ast.CallExpression, baseRange tokens.Range) ast.Expression {
+	hadBang := p.head().IsOfKind(tokens.TokenBang)
+	suffix := parseMemoizationSuffix(ctx, p)
+	if suffix == nil {
+		if hadBang {
+			return nil
+		}
+		return call
+	}
+	rnge := baseRange
+	rnge.To = suffix.To
+	return ast.NewCallExpression(call.Callee, call.Arguments, true, suffix.TTL, rnge)
+}

--- a/parser/pipeline_test.go
+++ b/parser/pipeline_test.go
@@ -28,20 +28,20 @@ func (s *ParserTestSuite) TestPipelineExpressionLowering() {
 		input    string
 		expected string
 	}{
-		{"value |> len", "len(value)"},
-		{"value |> str.trim", "str.trim(value)"},
+		{"value |> len()", "len(value)"},
+		{"value |> str.trim()", "str.trim(value)"},
 		{"value |> str.replaceAll(\" \", \"-\")", "str.replaceAll(value, \" \", \"-\")"},
-		{"value |> mod.sub.fn", "mod.sub.fn(value)"},
-		{"value |> len |> math.abs", "math.abs(len(value))"},
-		{"value |> str.trim |> len", "len(str.trim(value))"},
+		{"value |> mod.sub.fn()", "mod.sub.fn(value)"},
+		{"value |> len() |> math.abs()", "math.abs(len(value))"},
+		{"value |> str.trim() |> len()", "len(str.trim(value))"},
 		{"needle |> str.replace(haystack, #, \"$$\")", "str.replace(haystack, needle, \"$$\")"},
 		{"x |> f(1, #)", "f(1, x)"},
 		{"x |> f(#, 2)", "f(x, 2)"},
 		{"x |> f(#, #)", "f(x, x)"},
 		{"x |> f(1, #) |> g(#)", "g(f(1, x))"},
 		{"x |> f(g(#))", "f(g(x))"},
-		{"a + b |> len", "len((a + b))"},
-		{"a ? b : c |> len", "len((a ? b : c))"},
+		{"a + b |> len()", "len((a + b))"},
+		{"a ? b : c |> len()", "len((a ? b : c))"},
 	}
 
 	for _, tc := range testCases {
@@ -63,24 +63,6 @@ func (s *ParserTestSuite) TestPipelineExpressionMemoizationPreserved() {
 		expectMemoized bool
 		expectTTL      *time.Duration
 	}{
-		{
-			input:          "x |> f!",
-			expectedCall:   "f(x)",
-			expectMemoized: true,
-			expectTTL:      nil,
-		},
-		{
-			input:          "x |> f!10",
-			expectedCall:   "f(x)",
-			expectMemoized: true,
-			expectTTL:      durationPtr(10 * time.Second),
-		},
-		{
-			input:          "x |> mod.f!30",
-			expectedCall:   "mod.f(x)",
-			expectMemoized: true,
-			expectTTL:      durationPtr(30 * time.Second),
-		},
 		{
 			input:          "x |> f()!",
 			expectedCall:   "f(x)",
@@ -129,6 +111,14 @@ func (s *ParserTestSuite) TestPipelineExpressionInvalidTargets() {
 		{"value |>", false},
 		{"value |> (a + b)", true},
 		{"value |> foo ? bar : baz", true},
+		{"value |> len", true},
+		{"value |> str.trim", true},
+		{"value |> mod.sub.fn", true},
+		{"value |> len |> math.abs", true},
+		{"value |> str.trim |> len", true},
+		{"x |> f!", true},
+		{"x |> f!10", true},
+		{"x |> mod.f!30", true},
 		{"value |> [1, 2]", true},
 		{"value |> {\"k\": 1}", true},
 		{"value |> foo[0]", true},

--- a/parser/pipeline_test.go
+++ b/parser/pipeline_test.go
@@ -4,9 +4,11 @@
 package parser
 
 import (
+	"strings"
 	"time"
 
 	"github.com/sentrie-sh/sentrie/ast"
+	"github.com/sentrie-sh/sentrie/lexer"
 	"github.com/sentrie-sh/sentrie/tokens"
 )
 
@@ -265,4 +267,74 @@ func (s *ParserTestSuite) TestPipelineHoleHelpers() {
 
 func durationPtr(d time.Duration) *time.Duration {
 	return &d
+}
+
+func (s *ParserTestSuite) TestPrimaryLiteralParseErrors() {
+	rng := tokens.BadRange("test.sentra")
+
+	p := &Parser{
+		current: tokens.New(tokens.Int, "12x", rng),
+		next:    tokens.EofInstance("test.sentra", rng.To),
+	}
+	s.Nil(parseIntegerLiteral(s.T().Context(), p))
+	s.Error(p.err)
+	s.Contains(p.err.Error(), "invalid integer literal")
+
+	p = &Parser{
+		current: tokens.New(tokens.Float, "1.2.3", rng),
+		next:    tokens.EofInstance("test.sentra", rng.To),
+	}
+	s.Nil(parseFloatLiteral(s.T().Context(), p))
+	s.Error(p.err)
+	s.Contains(p.err.Error(), "invalid float literal")
+
+	p = &Parser{
+		current: tokens.New(tokens.Int, "42", rng),
+		next:    tokens.EofInstance("test.sentra", rng.To),
+	}
+	s.Nil(parseNullLiteral(s.T().Context(), p))
+	s.Error(p.err)
+	s.Contains(p.err.Error(), "expected `null` literal")
+}
+
+func (s *ParserTestSuite) TestParseCallExpressionErrorBranches() {
+	rng := tokens.BadRange("test.sentra")
+	left := ast.NewIdentifier("fn", rng)
+
+	p := NewParserFromString("fn", "test.sentra")
+	s.Nil(parseCallExpression(s.T().Context(), p, left, CALL))
+	s.Error(p.err)
+	s.Contains(p.err.Error(), "expected")
+
+	p = NewParserFromString("fn(,)", "test.sentra")
+	callHead := p.parseExpression(s.T().Context(), LOWEST)
+	s.Nil(callHead)
+	s.Error(p.err)
+
+	p = NewParserFromString("fn(1", "test.sentra")
+	s.Nil(p.parseExpression(s.T().Context(), LOWEST))
+	s.Error(p.err)
+	s.Contains(p.err.Error(), "expected")
+}
+
+func (s *ParserTestSuite) TestParseMemoizationSuffixBranches() {
+	p := NewParserFromString("!15", "test.sentra")
+	suffix := parseMemoizationSuffix(s.T().Context(), p)
+	s.NotNil(suffix)
+	if s.NotNil(suffix.TTL) {
+		s.Equal(15*time.Second, *suffix.TTL)
+	}
+
+	p = NewParserFromString("fn", "test.sentra")
+	s.Nil(parseMemoizationSuffix(s.T().Context(), p))
+
+	rng := tokens.BadRange("test.sentra")
+	p = &Parser{
+		lexer:   lexer.NewLexer(strings.NewReader(""), "test.sentra"),
+		current: tokens.New(tokens.TokenBang, "!", rng),
+		next:    tokens.New(tokens.Int, "not-a-number", rng),
+	}
+	s.Nil(parseMemoizationSuffix(s.T().Context(), p))
+	s.Error(p.err)
+	s.Contains(p.err.Error(), "invalid integer literal")
 }

--- a/parser/pipeline_test.go
+++ b/parser/pipeline_test.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2026 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package parser
 

--- a/parser/pipeline_test.go
+++ b/parser/pipeline_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright 2026 Binaek Sarkar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"time"
+
+	"github.com/sentrie-sh/sentrie/ast"
+	"github.com/sentrie-sh/sentrie/tokens"
+)
+
+func (s *ParserTestSuite) TestPipelineExpressionLowering() {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"value |> len", "len(value)"},
+		{"value |> str.trim", "str.trim(value)"},
+		{"value |> str.replaceAll(\" \", \"-\")", "str.replaceAll(value, \" \", \"-\")"},
+		{"value |> mod.sub.fn", "mod.sub.fn(value)"},
+		{"value |> len |> math.abs", "math.abs(len(value))"},
+		{"value |> str.trim |> len", "len(str.trim(value))"},
+		{"a + b |> len", "len((a + b))"},
+		{"a ? b : c |> len", "len((a ? b : c))"},
+	}
+
+	for _, tc := range testCases {
+		parser := NewParserFromString(tc.input, "test.sentra")
+		expr := parser.parseExpression(s.T().Context(), LOWEST)
+		s.NotNil(expr, "expression should parse: %s", tc.input)
+		s.Nil(parser.err, "expression should not produce parser error: %s", tc.input)
+		if expr == nil {
+			continue
+		}
+		s.Equal(tc.expected, expr.String(), "unexpected lowering for: %s", tc.input)
+	}
+}
+
+func (s *ParserTestSuite) TestPipelineExpressionMemoizationPreserved() {
+	testCases := []struct {
+		input          string
+		expectedCall   string
+		expectMemoized bool
+		expectTTL      *time.Duration
+	}{
+		{
+			input:          "x |> f!",
+			expectedCall:   "f(x)",
+			expectMemoized: true,
+			expectTTL:      nil,
+		},
+		{
+			input:          "x |> f!10",
+			expectedCall:   "f(x)",
+			expectMemoized: true,
+			expectTTL:      durationPtr(10 * time.Second),
+		},
+		{
+			input:          "x |> mod.f!30",
+			expectedCall:   "mod.f(x)",
+			expectMemoized: true,
+			expectTTL:      durationPtr(30 * time.Second),
+		},
+		{
+			input:          "x |> f()!",
+			expectedCall:   "f(x)",
+			expectMemoized: true,
+			expectTTL:      nil,
+		},
+		{
+			input:          "x |> f()!10",
+			expectedCall:   "f(x)",
+			expectMemoized: true,
+			expectTTL:      durationPtr(10 * time.Second),
+		},
+		{
+			input:          "x |> mod.f(1)!5",
+			expectedCall:   "mod.f(x, 1)",
+			expectMemoized: true,
+			expectTTL:      durationPtr(5 * time.Second),
+		},
+	}
+
+	for _, tc := range testCases {
+		parser := NewParserFromString(tc.input, "test.sentra")
+		expr := parser.parseExpression(s.T().Context(), LOWEST)
+		s.NotNil(expr, "expression should parse: %s", tc.input)
+		s.Nil(parser.err, "expression should not produce parser error: %s", tc.input)
+
+		call, ok := expr.(*ast.CallExpression)
+		s.True(ok, "expected call expression for: %s", tc.input)
+		s.Equal(tc.expectedCall, call.String(), "unexpected lowered call for: %s", tc.input)
+		s.Equal(tc.expectMemoized, call.Memoized, "unexpected memoized flag for: %s", tc.input)
+
+		if tc.expectTTL == nil {
+			s.Nil(call.MemoizeTTL, "expected nil ttl for: %s", tc.input)
+		} else {
+			s.NotNil(call.MemoizeTTL, "expected ttl for: %s", tc.input)
+			s.Equal(*tc.expectTTL, *call.MemoizeTTL, "unexpected ttl for: %s", tc.input)
+		}
+	}
+}
+
+func (s *ParserTestSuite) TestPipelineExpressionInvalidTargets() {
+	testCases := []struct {
+		input            string
+		expectPipelineEr bool
+	}{
+		{"value |>", false},
+		{"value |> (a + b)", true},
+		{"value |> foo ? bar : baz", true},
+		{"value |> [1, 2]", true},
+		{"value |> {\"k\": 1}", true},
+		{"value |> foo[0]", true},
+		{"value |> foo().bar", true},
+		{"value |> foo().bar()", true},
+		{"value |> (str.trim)", true},
+	}
+
+	for _, tc := range testCases {
+		parser := NewParserFromString(tc.input, "test.sentra")
+		expr := parser.parseExpression(s.T().Context(), LOWEST)
+		s.Nil(expr, "expected parse failure for invalid pipeline target: %s", tc.input)
+		s.NotNil(parser.err, "expected parser error for: %s", tc.input)
+		if tc.expectPipelineEr {
+			s.Contains(parser.err.Error(), "pipeline", "expected pipeline-specific error for: %s", tc.input)
+		}
+	}
+}
+
+func (s *ParserTestSuite) TestHasIdentifierRoot() {
+	rng := tokens.BadRange("test.sentra")
+	s.True(hasIdentifierRoot(ast.NewIdentifier("f", rng)))
+	s.True(
+		hasIdentifierRoot(
+			ast.NewFieldAccessExpression(
+				ast.NewIdentifier("mod", rng),
+				"fn",
+				rng,
+			),
+		),
+	)
+	s.False(
+		hasIdentifierRoot(
+			ast.NewFieldAccessExpression(
+				ast.NewCallExpression(
+					ast.NewIdentifier("factory", rng),
+					nil,
+					false,
+					nil,
+					rng,
+				),
+				"fn",
+				rng,
+			),
+		),
+	)
+}
+
+func durationPtr(d time.Duration) *time.Duration {
+	return &d
+}

--- a/parser/pipeline_test.go
+++ b/parser/pipeline_test.go
@@ -34,6 +34,12 @@ func (s *ParserTestSuite) TestPipelineExpressionLowering() {
 		{"value |> mod.sub.fn", "mod.sub.fn(value)"},
 		{"value |> len |> math.abs", "math.abs(len(value))"},
 		{"value |> str.trim |> len", "len(str.trim(value))"},
+		{"needle |> str.replace(haystack, #, \"$$\")", "str.replace(haystack, needle, \"$$\")"},
+		{"x |> f(1, #)", "f(1, x)"},
+		{"x |> f(#, 2)", "f(x, 2)"},
+		{"x |> f(#, #)", "f(x, x)"},
+		{"x |> f(1, #) |> g(#)", "g(f(1, x))"},
+		{"x |> f(g(#))", "f(g(x))"},
 		{"a + b |> len", "len((a + b))"},
 		{"a ? b : c |> len", "len((a ? b : c))"},
 	}
@@ -128,6 +134,7 @@ func (s *ParserTestSuite) TestPipelineExpressionInvalidTargets() {
 		{"value |> foo[0]", true},
 		{"value |> foo().bar", true},
 		{"value |> foo().bar()", true},
+		{"value |> #", true},
 		{"value |> (str.trim)", true},
 	}
 
@@ -169,6 +176,114 @@ func (s *ParserTestSuite) TestHasIdentifierRoot() {
 			),
 		),
 	)
+}
+
+func (s *ParserTestSuite) TestPipelineHoleHelpers() {
+	rng := tokens.BadRange("test.sentra")
+	replacement := ast.NewIdentifier("x", rng)
+
+	exprs := []struct {
+		name     string
+		input    ast.Expression
+		expected string
+	}{
+		{
+			name:     "call",
+			input:    ast.NewCallExpression(ast.NewIdentifier("f", rng), []ast.Expression{ast.NewPipelineHoleExpression(rng)}, false, nil, rng),
+			expected: "f(x)",
+		},
+		{
+			name: "field_access_left",
+			input: ast.NewFieldAccessExpression(
+				ast.NewPipelineHoleExpression(rng),
+				"trim",
+				rng,
+			),
+			expected: "x.trim",
+		},
+		{
+			name: "index_access",
+			input: ast.NewIndexAccessExpression(
+				ast.NewIdentifier("arr", rng),
+				ast.NewPipelineHoleExpression(rng),
+				rng,
+			),
+			expected: "arr[x]",
+		},
+		{
+			name:     "list",
+			input:    ast.NewListLiteral([]ast.Expression{ast.NewPipelineHoleExpression(rng)}, rng),
+			expected: "[x]",
+		},
+		{
+			name: "map",
+			input: ast.NewMapLiteral([]ast.MapEntry{{
+				Key:   ast.NewStringLiteral("k", rng),
+				Value: ast.NewPipelineHoleExpression(rng),
+			}}, rng),
+			expected: "{k: x}",
+		},
+		{
+			name:     "infix",
+			input:    ast.NewInfixExpression(ast.NewPipelineHoleExpression(rng), ast.NewIntegerLiteral(1, rng), "+", rng),
+			expected: "(x + 1)",
+		},
+		{
+			name:     "unary",
+			input:    ast.NewUnaryExpression("-", ast.NewPipelineHoleExpression(rng), rng),
+			expected: "-x",
+		},
+		{
+			name: "ternary",
+			input: ast.NewTernaryExpression(
+				ast.NewPipelineHoleExpression(rng),
+				ast.NewIntegerLiteral(1, rng),
+				ast.NewIntegerLiteral(0, rng),
+				rng,
+			),
+			expected: "(x ? 1 : 0)",
+		},
+		{
+			name:     "cast",
+			input:    ast.NewCastExpression(ast.NewPipelineHoleExpression(rng), ast.NewNumberTypeRef(rng), rng),
+			expected: "cast x as number",
+		},
+		{
+			name:     "is_defined",
+			input:    ast.NewIsDefinedExpression(ast.NewPipelineHoleExpression(rng), rng),
+			expected: "is defined x",
+		},
+		{
+			name:     "is_empty",
+			input:    ast.NewIsEmptyExpression(ast.NewPipelineHoleExpression(rng), rng),
+			expected: "is empty x",
+		},
+		{
+			name:     "transform",
+			input:    ast.NewTransformExpression(ast.NewPipelineHoleExpression(rng), "to_number", rng),
+			expected: "transform  x to_number",
+		},
+		{
+			name:     "preceding_comment",
+			input:    ast.NewPrecedingCommentExpression("c", ast.NewPipelineHoleExpression(rng), rng),
+			expected: "c -- x",
+		},
+		{
+			name:     "trailing_comment",
+			input:    ast.NewTrailingCommentExpression("c", ast.NewPipelineHoleExpression(rng), rng),
+			expected: "x -- c",
+		},
+	}
+
+	for _, tc := range exprs {
+		s.True(containsPipelineHole(tc.input), tc.name)
+		got := substitutePipelineHoles(tc.input, replacement)
+		s.Equal(tc.expected, got.String(), tc.name)
+		s.False(containsPipelineHole(got), tc.name)
+	}
+
+	s.False(containsPipelineHole(ast.NewIdentifier("plain", rng)))
+	s.False(containsPipelineHoleInExprs([]ast.Expression{ast.NewIdentifier("plain", rng)}))
 }
 
 func durationPtr(d time.Duration) *time.Duration {

--- a/parser/precedence.go
+++ b/parser/precedence.go
@@ -23,6 +23,7 @@ type Precedence uint8
 
 const (
 	LOWEST     Precedence = iota
+	PIPELINE             // |>
 	TERNARY               // ? :
 	OR                    // or
 	XOR                   // xor
@@ -38,6 +39,7 @@ const (
 )
 
 var precedences = map[tokens.Kind]Precedence{
+	tokens.TokenPipeForward:     PIPELINE,
 	tokens.TokenQuestion:        TERNARY,
 	tokens.KeywordOr:            OR,
 	tokens.KeywordXor:           XOR,

--- a/parser/precedence.go
+++ b/parser/precedence.go
@@ -10,7 +10,7 @@ type Precedence uint8
 
 const (
 	LOWEST     Precedence = iota
-	PIPELINE             // |>
+	PIPELINE              // |>
 	TERNARY               // ? :
 	OR                    // or
 	XOR                   // xor

--- a/parser/precedence.go
+++ b/parser/precedence.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package parser
 

--- a/parser/primary.go
+++ b/parser/primary.go
@@ -46,6 +46,11 @@ func parseIdentifier(ctx context.Context, p *Parser) ast.Expression {
 	return ast.NewIdentifier(token.Value, token.Range)
 }
 
+func parsePipelineHoleExpression(ctx context.Context, p *Parser) ast.Expression {
+	token := p.advance()
+	return ast.NewPipelineHoleExpression(token.Range)
+}
+
 func parseIntegerLiteral(ctx context.Context, p *Parser) ast.Expression {
 	token := p.advance()
 	value, err := strconv.ParseInt(token.Value, 10, 64)

--- a/parser/primary.go
+++ b/parser/primary.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package parser
 

--- a/runtime/eval.go
+++ b/runtime/eval.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2026 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package runtime
 

--- a/runtime/eval.go
+++ b/runtime/eval.go
@@ -121,6 +121,10 @@ func eval(ctx context.Context, ec *ExecutionContext, exec *executorImpl, p *inde
 	case *ast.Identifier:
 		return evalIdent(ctx, ec, exec, p, t)
 
+	case *ast.PipelineHoleExpression:
+		err := fmt.Errorf("pipeline placeholder '#' must be used inside a pipeline call target")
+		return box.Undefined(), trace.UnsupportedExpression(t).SetErr(err), err
+
 	case *ast.CastExpression:
 		return evalCast(ctx, ec, exec, p, t)
 

--- a/runtime/eval_call_test.go
+++ b/runtime/eval_call_test.go
@@ -111,3 +111,28 @@ func (s *RuntimeTestSuite) TestCalculateHashKeyNumericEdges() {
 	s.Require().NotEmpty(hashInf)
 	s.Require().NotEqual(hashNegZero, hashPosZero)
 }
+
+func (s *RuntimeTestSuite) TestGetTargetDoesNotResolveImportedFunctionAsBareIdentifier() {
+	p := newEvalTestPolicy()
+	p.Uses = map[string]*ast.UseStatement{
+		"string": ast.NewUseStatement(
+			[]string{"trim"},
+			"",
+			[]string{"sentrie", "string"},
+			"string",
+			stubRange(),
+		),
+	}
+	ec := NewExecutionContext(p, &executorImpl{})
+	call := ast.NewCallExpression(
+		ast.NewIdentifier("trim", stubRange()),
+		[]ast.Expression{},
+		false,
+		nil,
+		stubRange(),
+	)
+
+	_, err := getTarget(s.T().Context(), ec, &executorImpl{}, p, call)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "unable to resolve import")
+}

--- a/runtime/eval_call_test.go
+++ b/runtime/eval_call_test.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2026 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package runtime
 

--- a/runtime/eval_call_test.go
+++ b/runtime/eval_call_test.go
@@ -136,3 +136,13 @@ func (s *RuntimeTestSuite) TestGetTargetDoesNotResolveImportedFunctionAsBareIden
 	s.Require().Error(err)
 	s.Require().Contains(err.Error(), "unable to resolve import")
 }
+
+func (s *RuntimeTestSuite) TestPipelineHoleOutsidePipelineErrors() {
+	p := newEvalTestPolicy()
+	ec := NewExecutionContext(p, &executorImpl{})
+	hole := ast.NewPipelineHoleExpression(stubRange())
+
+	_, _, err := eval(s.T().Context(), ec, &executorImpl{}, p, hole)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "pipeline placeholder '#'")
+}

--- a/runtime/js/ts_src/_sentrie_js.ts
+++ b/runtime/js/ts_src/_sentrie_js.ts
@@ -52,6 +52,7 @@ export const MIN_VALUE = Number.MIN_VALUE;
 // String functions
 export const length = (str: string) => str.length;
 export const fromCharCode = String.fromCharCode;
+export const replaceAll = (str: string, search: string, replace: string) => str.replaceAll(search, replace);
 
 // Number functions
 export const isNaN = Number.isNaN;

--- a/runtime/value_test.go
+++ b/runtime/value_test.go
@@ -35,7 +35,7 @@ const (
 	ValueString    = box.ValueString
 	ValueTrinary   = box.ValueTrinary
 	ValueList      = box.ValueList
-	ValueDict       = box.ValueDict
+	ValueDict      = box.ValueDict
 	ValueObject    = box.ValueObject
 )
 

--- a/tokens/token_kind.go
+++ b/tokens/token_kind.go
@@ -105,6 +105,8 @@ const (
 	TokenAt        Kind = "At"
 	TokenFatArrow  Kind = "FatArrow"
 
+	TokenPipeForward Kind = "PipeForward"
+
 	// Punctuation
 	PunctComma            Kind = "Comma"
 	PunctSemicolon        Kind = "Semicolon"

--- a/tokens/token_kind.go
+++ b/tokens/token_kind.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package tokens
 

--- a/tokens/token_kind.go
+++ b/tokens/token_kind.go
@@ -103,7 +103,9 @@ const (
 	TokenDot       Kind = "Dot"
 	TokenDotDotDot Kind = "DotDotDot"
 	TokenAt        Kind = "At"
-	TokenFatArrow  Kind = "FatArrow"
+
+	TokenPipelineHole Kind = "PipelineHole"
+	TokenFatArrow     Kind = "FatArrow"
 
 	TokenPipeForward Kind = "PipeForward"
 

--- a/tokens/token_kind.go
+++ b/tokens/token_kind.go
@@ -103,11 +103,10 @@ const (
 	TokenDot       Kind = "Dot"
 	TokenDotDotDot Kind = "DotDotDot"
 	TokenAt        Kind = "At"
+	TokenFatArrow  Kind = "FatArrow"
 
 	TokenPipelineHole Kind = "PipelineHole"
-	TokenFatArrow     Kind = "FatArrow"
-
-	TokenPipeForward Kind = "PipeForward"
+	TokenPipeForward  Kind = "PipeForward"
 
 	// Punctuation
 	PunctComma            Kind = "Comma"

--- a/tokens/token_kind_test.go
+++ b/tokens/token_kind_test.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package tokens
+
+import "testing"
+
+func TestIsKeywordRecognizesKnownAndUnknownValues(t *testing.T) {
+	kind, ok := IsKeyword("transform")
+	if !ok {
+		t.Fatalf("expected transform to be recognized as keyword")
+	}
+	if kind != KeywordTransform {
+		t.Fatalf("expected transform keyword kind, got %s", kind)
+	}
+
+	if _, ok = IsKeyword("transformer"); ok {
+		t.Fatalf("did not expect non-keyword value to be recognized")
+	}
+}
+
+func TestKindStringReturnsUnderlyingValue(t *testing.T) {
+	if got := TokenPipeForward.String(); got != "PipeForward" {
+		t.Fatalf("unexpected kind string for pipe forward: %q", got)
+	}
+
+	if got := KeywordContains.String(); got != "contains" {
+		t.Fatalf("unexpected kind string for keyword: %q", got)
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -21,6 +21,8 @@ import (
 	"runtime/debug"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/Masterminds/semver/v3"
 )
 
 // Info holds version information for the application.
@@ -107,7 +109,8 @@ func (i Info) String() string {
 	// App details
 	if i.Name != "" {
 		if i.GitVersion != "" {
-			_, _ = fmt.Fprintf(&b, "%s v%s\n", i.Name, i.GitVersion)
+			v := semver.MustParse(i.GitVersion)
+			_, _ = fmt.Fprintf(&b, "%s v%s\n", i.Name, v.String())
 		} else {
 			_, _ = fmt.Fprintf(&b, "%s\n", i.Name)
 		}

--- a/version/version.go
+++ b/version/version.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2026 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package version
 


### PR DESCRIPTION

## Summary

- Introduces the `|>` pipeline operator as parse-time sugar: pipelines lower to ordinary `CallExpression` nodes with the same runtime semantics as nested calls.
- Adds `#` as a pipeline placeholder inside RHS call arguments so the piped value can be threaded into non-first positions.
- Tightens pipeline targets: the RHS must be a **call** whose callee is an identifier or module-qualified field access (for example `x |> len()`, not `x |> len`).
- Extends `lexer`, `parser`, `AST`, `runtime`, `tests`, and example policies; normalizes CLI version output formatting and refreshes the example pack manifest.

## What this PR does

- Lexes `|>` as a single token and rejects ambiguous bare `|` at the lexer.
- Parses `|>` at the lowest infix precedence so pipelines read top-to-bottom without fighting arithmetic, logical, or ternary binding.
- Lowers valid pipelines to calls: by default prepends the left-hand value as the first argument; when `#` appears anywhere in the RHS argument list, substitutes each `#` with the piped value and does **not** auto-prepend.
- Rejects grouped RHS expressions (parenthesized pipeline targets), call targets whose callee root is not identifier/field-access shaped, and stray `#` at evaluation time.
- Preserves memoization metadata (`Memoized`, `MemoizeTTL`) on pipeline-lowered calls when the RHS call carried it; memoization suffix parsing is shared between ordinary calls and pipeline contexts via `parser/memoization.go`.

## Changes By Area

### Tokens and lexer

- Adds `TokenPipeForward` and lexing for `|>` in `tokens/token_kind.go` and `lexer/lexer.go`.
- Expands `lexer/lexer_test.go` for happy paths, whitespace/newline edge cases, and invalid `|` forms.

### AST

- Adds `ast/pipeline_hole.go` and `PipelineHoleExpression` for `#` in the parse tree.
- Extends `ast/node_test.go` for the new node kind.

### Parser

- Registers pipeline infix handling in `parser/lookups.go` and `PIPELINE` precedence in `parser/precedence.go`.
- Implements `parser/pipeline.go`: `parsePipelineExpression`, callee-root validation, hole detection/substitution, and grouped-RHS rejection.
- Wires `#` as a prefix expression in `parser/primary.go`.
- Refactors call memoization suffix parsing into `parser/memoization.go` and uses it from `parser/call.go`.
- Adds `parser/pipeline_test.go` (lowering, holes, invalid targets, memoization on calls, helpers) and extends `parser/error_test.go` where relevant.

### Runtime

- Evaluates stray `PipelineHoleExpression` with a clear error in `runtime/eval.go`.
- Adds regression coverage in `runtime/eval_call_test.go` (`import`/`use` resolution behavior unchanged by pipelines).

### Example pack and packaging

- Adds `example_pack/pipeline_*.sentrie` samples (basics, module calls, memoized calls, placeholders).
- Updates `example_pack/minimal.sentrie` for current higher-order / lambda style.
- Refreshes `example_pack/sentrie.pack.toml` metadata and constraints.

### Version and ancillary

- Normalizes reported version string formatting in `version/version.go` (semver-aware output).
- One-line touch in `runtime/js/ts_src/_sentrie_js.ts` for the JS runtime shim.

### Planning artifacts

- Adds `.cursor/plans/` markdown for issue #76 (pipeline operator and hole syntax notes).

## Review Notes

- Confirm pipeline RHS is **always** a call and that bare identifiers or field accesses without `()` are rejected consistently with docs and examples.
- Confirm `#` substitution only runs inside RHS **argument** positions and never leaves a hole in the lowered tree.
- Verify callee-root rules: allow `fn()` and `alias.method()`; reject roots like `foo().bar()` or other non-identifier/field-access callees.
- Check memoization: TTL and `Memoized` survive lowering; invalid `!` after non-call RHS should not apply (RHS must be a call).
- Ensure `use` / module alias semantics are unchanged—pipelines do not introduce new bindings.

## Testing Notes

- `go test ./lexer ./parser ./runtime`
- Focused pipeline coverage: `go test ./parser -run Pipeline -count=1`

## Dependency changes

- None.
