### PR TITLE
Fix POST /decision success-path nil panic. Closes #114

### DIFF
--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -1,27 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/sentrie-sh/sentrie/runtime"
+	"github.com/sentrie-sh/sentrie/xerr"
 )
 
 // DecisionRequest represents the request body for rule execution
@@ -93,16 +82,26 @@ func (api *HTTPAPI) handleDecision(w http.ResponseWriter, r *http.Request) {
 		outputs, runErr = api.executor.ExecPolicy(ctx, namespace, policy, req.Facts)
 	} else {
 		output, e := api.executor.ExecRule(ctx, namespace, policy, rule, req.Facts)
-		outputs = []*runtime.ExecutorOutput{output}
+		if output != nil {
+			outputs = []*runtime.ExecutorOutput{output}
+		}
 		runErr = e
+	}
+
+	if runErr != nil {
+		status := http.StatusInternalServerError
+		var invErr xerr.InvalidInvocationError
+		if errors.As(runErr, &invErr) {
+			status = http.StatusBadRequest
+		}
+		api.writeErrorResponse(w, r, status, "Evaluation Failed", runErr.Error())
+		return
 	}
 
 	response := DecisionResponse{
 		Decisions: outputs,
-		Error:     runErr.Error(),
 	}
 
-	// Write JSON response
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 

--- a/api/handle_decision_test.go
+++ b/api/handle_decision_test.go
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/sentrie-sh/sentrie/api/middleware"
+	"github.com/sentrie-sh/sentrie/index"
+	"github.com/sentrie-sh/sentrie/loader"
+	runtimepkg "github.com/sentrie-sh/sentrie/runtime"
+)
+
+func examplePackDir() string {
+	_, current, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(current), "..", "example_pack")
+}
+
+func (s *APITestSuite) newExamplePackHTTPAPI() *HTTPAPI {
+	ctx := s.T().Context()
+
+	packFile, err := loader.LoadPack(ctx, examplePackDir())
+	s.Require().NoError(err)
+
+	programs, err := loader.LoadPrograms(ctx, packFile)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(programs)
+
+	idx := index.CreateIndex()
+	s.Require().NoError(idx.SetPack(ctx, packFile))
+	for _, program := range programs {
+		s.Require().NoError(idx.AddProgram(ctx, program))
+	}
+	s.Require().NoError(idx.Validate(ctx))
+
+	exec, err := runtimepkg.NewExecutor(idx)
+	s.Require().NoError(err)
+
+	return NewHTTPAPI(exec)
+}
+
+func (s *APITestSuite) decisionHandler(api *HTTPAPI) http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle("POST /decision/{target...}",
+		middleware.RequestIDMiddleware(http.HandlerFunc(api.handleDecision)),
+	)
+	return mux
+}
+
+func (s *APITestSuite) postDecision(api *HTTPAPI, path string, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.decisionHandler(api).ServeHTTP(rec, req)
+	return rec
+}
+
+func (s *APITestSuite) TestHandleDecisionPolicySuccess() {
+	api := s.newExamplePackHTTPAPI()
+
+	rec := s.postDecision(api, "/decision/sh/sentrie/example/user_access", `{
+		"facts": {
+			"user": {"role": "admin", "status": "active"}
+		}
+	}`)
+
+	s.Equal(http.StatusOK, rec.Code)
+	s.Equal("application/json", rec.Header().Get("Content-Type"))
+
+	var payload map[string]json.RawMessage
+	s.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &payload))
+	s.Contains(payload, "decisions")
+	s.NotContains(payload, "error")
+
+	var decisions []json.RawMessage
+	s.Require().NoError(json.Unmarshal(payload["decisions"], &decisions))
+	s.NotEmpty(decisions)
+}
+
+func (s *APITestSuite) TestHandleDecisionRuleSuccess() {
+	api := s.newExamplePackHTTPAPI()
+
+	rec := s.postDecision(api, "/decision/sh/sentrie/example/user_access/allow_admin", `{
+		"facts": {
+			"user": {"role": "admin", "status": "active"}
+		}
+	}`)
+
+	s.Equal(http.StatusOK, rec.Code)
+
+	var payload map[string]json.RawMessage
+	s.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &payload))
+	s.Contains(payload, "decisions")
+	s.NotContains(payload, "error")
+
+	var decisions []json.RawMessage
+	s.Require().NoError(json.Unmarshal(payload["decisions"], &decisions))
+	s.Len(decisions, 1)
+}
+
+func (s *APITestSuite) TestHandleDecisionMissingRequiredFact() {
+	api := s.newExamplePackHTTPAPI()
+
+	rec := s.postDecision(api, "/decision/sh/sentrie/example/user_access", `{"facts": {}}`)
+
+	s.Equal(http.StatusBadRequest, rec.Code)
+	s.Equal("application/problem+json", rec.Header().Get("Content-Type"))
+
+	var problem ProblemDetails
+	s.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &problem))
+	s.Equal(http.StatusBadRequest, problem.Status)
+	s.Equal("Evaluation Failed", problem.Title)
+	s.Contains(problem.Detail, "required fact not found: user")
+}
+
+func (s *APITestSuite) TestHandleDecisionEvaluationInternalError() {
+	api := s.newExamplePackHTTPAPI()
+
+	rec := s.postDecision(api, "/decision/sh/sentrie/example/shapes/example", `{"facts": {}}`)
+
+	s.Equal(http.StatusInternalServerError, rec.Code)
+	s.Equal("application/problem+json", rec.Header().Get("Content-Type"))
+
+	var problem ProblemDetails
+	s.Require().NoError(json.Unmarshal(rec.Body.Bytes(), &problem))
+	s.Equal(http.StatusInternalServerError, problem.Status)
+	s.Equal("Evaluation Failed", problem.Title)
+	s.Contains(problem.Detail, "invalid value for let declaration user")
+}
+
+func (s *APITestSuite) TestHandleDecisionInvalidPath() {
+	api := s.newExamplePackHTTPAPI()
+
+	rec := s.postDecision(api, "/decision/does/not/exist", `{"facts": {}}`)
+
+	s.Equal(http.StatusNotFound, rec.Code)
+	s.Equal("application/problem+json", rec.Header().Get("Content-Type"))
+}
+
+func (s *APITestSuite) TestHandleDecisionInvalidJSON() {
+	api := s.newExamplePackHTTPAPI()
+
+	req := httptest.NewRequest(http.MethodPost, "/decision/sh/sentrie/example/user_access", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.decisionHandler(api).ServeHTTP(rec, req)
+
+	s.Equal(http.StatusBadRequest, rec.Code)
+	s.Equal("application/problem+json", rec.Header().Get("Content-Type"))
+}

--- a/api/handle_decision_test.go
+++ b/api/handle_decision_test.go
@@ -23,7 +23,11 @@ func examplePackDir() string {
 	return filepath.Join(filepath.Dir(current), "..", "example_pack")
 }
 
-func (s *APITestSuite) newExamplePackHTTPAPI() *HTTPAPI {
+func (s *APITestSuite) examplePackHTTPAPI() *HTTPAPI {
+	if s.examplePackAPI != nil {
+		return s.examplePackAPI
+	}
+
 	ctx := s.T().Context()
 
 	packFile, err := loader.LoadPack(ctx, examplePackDir())
@@ -43,7 +47,8 @@ func (s *APITestSuite) newExamplePackHTTPAPI() *HTTPAPI {
 	exec, err := runtimepkg.NewExecutor(idx)
 	s.Require().NoError(err)
 
-	return NewHTTPAPI(exec)
+	s.examplePackAPI = NewHTTPAPI(exec)
+	return s.examplePackAPI
 }
 
 func (s *APITestSuite) decisionHandler(api *HTTPAPI) http.Handler {
@@ -63,7 +68,7 @@ func (s *APITestSuite) postDecision(api *HTTPAPI, path string, body string) *htt
 }
 
 func (s *APITestSuite) TestHandleDecisionPolicySuccess() {
-	api := s.newExamplePackHTTPAPI()
+	api := s.examplePackHTTPAPI()
 
 	rec := s.postDecision(api, "/decision/sh/sentrie/example/user_access", `{
 		"facts": {
@@ -85,7 +90,7 @@ func (s *APITestSuite) TestHandleDecisionPolicySuccess() {
 }
 
 func (s *APITestSuite) TestHandleDecisionRuleSuccess() {
-	api := s.newExamplePackHTTPAPI()
+	api := s.examplePackHTTPAPI()
 
 	rec := s.postDecision(api, "/decision/sh/sentrie/example/user_access/allow_admin", `{
 		"facts": {
@@ -106,7 +111,7 @@ func (s *APITestSuite) TestHandleDecisionRuleSuccess() {
 }
 
 func (s *APITestSuite) TestHandleDecisionMissingRequiredFact() {
-	api := s.newExamplePackHTTPAPI()
+	api := s.examplePackHTTPAPI()
 
 	rec := s.postDecision(api, "/decision/sh/sentrie/example/user_access", `{"facts": {}}`)
 
@@ -121,7 +126,7 @@ func (s *APITestSuite) TestHandleDecisionMissingRequiredFact() {
 }
 
 func (s *APITestSuite) TestHandleDecisionEvaluationInternalError() {
-	api := s.newExamplePackHTTPAPI()
+	api := s.examplePackHTTPAPI()
 
 	rec := s.postDecision(api, "/decision/sh/sentrie/example/shapes/example", `{"facts": {}}`)
 
@@ -136,7 +141,7 @@ func (s *APITestSuite) TestHandleDecisionEvaluationInternalError() {
 }
 
 func (s *APITestSuite) TestHandleDecisionInvalidPath() {
-	api := s.newExamplePackHTTPAPI()
+	api := s.examplePackHTTPAPI()
 
 	rec := s.postDecision(api, "/decision/does/not/exist", `{"facts": {}}`)
 
@@ -145,7 +150,7 @@ func (s *APITestSuite) TestHandleDecisionInvalidPath() {
 }
 
 func (s *APITestSuite) TestHandleDecisionInvalidJSON() {
-	api := s.newExamplePackHTTPAPI()
+	api := s.examplePackHTTPAPI()
 
 	req := httptest.NewRequest(http.MethodPost, "/decision/sh/sentrie/example/user_access", bytes.NewReader([]byte("not json")))
 	req.Header.Set("Content-Type", "application/json")

--- a/api/suite_test.go
+++ b/api/suite_test.go
@@ -24,6 +24,7 @@ import (
 
 type APITestSuite struct {
 	suite.Suite
+	examplePackAPI *HTTPAPI
 }
 
 func TestAPITestSuite(t *testing.T) {

--- a/docs/codebase-graph/api.handle_decision.md
+++ b/docs/codebase-graph/api.handle_decision.md
@@ -25,18 +25,15 @@ The only functional endpoint in the service and the whole reason the API exists:
 
 - **Signature:** `POST /decision/{namespace}/{policy}[/{rule}]`
   - **Request:** `DecisionRequest` - `{"facts": {"name": <any>, ...}}`. Query parameters are collected into a `runConfig` map.
-  - **Response:** `DecisionResponse` - `{"decisions": [ExecutorOutput...], "error": "..."}`.
+  - **Response:** `DecisionResponse` - `{"decisions": [ExecutorOutput...]}` on success; RFC 9457 Problem Details on evaluation failure.
   - **Behavior:** Sets CORS headers, validates the path, short-circuits `OPTIONS`, rejects non-POST, resolves segments, parses query parameters, decodes the body, evaluates, and encodes.
   - **Side Effects:** Full policy evaluation - JavaScript execution, memoization cache writes, VM pool acquisition.
-  - **Exceptions:** Problem Details for missing path (400), unresolvable path (404), wrong method (405), and unparseable JSON (400).
+  - **Exceptions:** Problem Details for missing path (400), unresolvable path (404), wrong method (405), unparseable JSON (400), and evaluation failures (400 for invalid invocation, 500 otherwise).
 
 ## 4. Operational Context & Gotchas
 - **Statefulness:** Stateless per request; all state lives in the shared executor.
 - **Performance/Scale Notes:** Unbounded work per request. The body is decoded without a size limit, facts flow into evaluation where collection builtins multiply over them, and the trace tree allocates a node per evaluation step. Request cost is a function of both payload size and policy complexity, neither of which is capped.
 - **Dependencies Risk:**
-  - **The success path panics.** `Error: runErr.Error()` is evaluated unconditionally, and `runErr` is nil whenever evaluation succeeds - so **every successful request** dereferences nil. `net/http` recovers per-connection, so the caller sees an empty reply and the computed decision is discarded. The `json:"error,omitempty"` tag shows the intent was conditional. Filed as [#114](https://github.com/sentrie-sh/sentrie/issues/114). Note the CLI equivalent in [[cmd]] checks `runErr != nil` correctly, so this handler is the outlier.
-  - **A nil output is wrapped into the response.** The `ExecRule` branch builds `[]*ExecutorOutput{output}` without a nil check, and `ExecRule` returns nil on many failure paths - serialising as `[null]`.
-  - **Every response is HTTP 200**, including evaluation failures, so status codes cannot be used to distinguish success from failure.
   - **`runConfig` is built from query parameters and never used.** Dead code that reads as though per-request configuration is supported.
   - **`strings.TrimPrefix(path, "/decision/")` is a no-op.** `r.PathValue("target")` already excludes the route prefix.
   - **CORS is wildcard and unconditional**, and the `OPTIONS` short-circuit is checked *after* the path validation, so a preflight for an empty path gets a 400 instead of the expected 200.

--- a/docs/codebase-graph/api.md
+++ b/docs/codebase-graph/api.md
@@ -34,7 +34,7 @@ The network-facing façade over the policy engine. It translates HTTP requests i
   - **Exceptions:** Bind failures.
 
 - **Signature:** `POST /decision/{target...}` - see [[api.handle_decision]]
-  - **Behavior:** The only functional endpoint. Body is `{"facts": {...}}`; response is `{"decisions": [...], "error": "..."}`.
+  - **Behavior:** The only functional endpoint. Body is `{"facts": {...}}`; response is `{"decisions": [...]}` on success, or RFC 9457 Problem Details on evaluation failure.
   - **Side Effects:** Full policy evaluation.
   - **Exceptions:** RFC 9457 Problem Details on the handled error paths.
 
@@ -47,7 +47,6 @@ The network-facing façade over the policy engine. It translates HTTP requests i
 - **Statefulness:** `HTTPAPI` owns its listeners and a shared executor. The executor is concurrency-safe by design, so one instance serves all requests and all connections share the JavaScript VM pool and the memoization cache.
 - **Performance/Scale Notes:** Read and write timeouts are fixed at 30 seconds with no configuration. There is **no concurrency limit**, so inbound request concurrency maps directly onto executor concurrency; the VM pool (max 10) becomes the implicit bottleneck under load, and requests queue on it invisibly.
 - **Dependencies Risk:**
-  - **The success path panics.** `handleDecision` calls `runErr.Error()` on a nil error, so a successful evaluation never produces a response. Filed as [#114](https://github.com/sentrie-sh/sentrie/issues/114) - see [[api.handle_decision]].
   - **No authentication, no authorization, no rate limiting, wildcard CORS, and no request body limit.** Filed as [#115](https://github.com/sentrie-sh/sentrie/issues/115). The default bind of `local` is the one thing keeping the out-of-the-box posture safe.
   - **`local6` and `network6` cannot bind** because the addresses are double-bracketed - see [[api.net]].
   - **Responses embed the full trace tree**, which contains evaluated fact values. Any caller that can reach the endpoint can read back the data the policy saw.

--- a/docs/codebase-graph/api.problem_details.md
+++ b/docs/codebase-graph/api.problem_details.md
@@ -45,4 +45,4 @@ The standard error representation for every handled HTTP failure, implementing R
   - **`Status` of zero is omitted**, meaning a caller who forgets to set it produces a body with no status member while the HTTP status is whatever `writeErrorResponse` was given - the two can disagree with no signal.
   - **The `type` URI points at `https://sentrie.sh/problems/{status}`**, which mirrors the HTTP status rather than identifying the specific problem. The RFC intends `type` to distinguish problem *kinds*, so two unrelated 400s are indistinguishable by type.
   - **`NewProblemDetails` is dead code**, and the divergence between it and the literal construction in `writeErrorResponse` means a future change to one will not affect the other.
-  - **Problem Details are only used for handler-level failures.** Evaluation errors come back as HTTP 200 with an `error` string in the normal response body, so clients need two error-handling paths - see [[api.handle_decision]].
+  - **Evaluation errors return Problem Details** with HTTP 400 for `InvalidInvocationError` (missing or invalid facts) and HTTP 500 otherwise — see [[api.handle_decision]].


### PR DESCRIPTION

## Summary

- Fixes a nil-pointer panic on every successful `POST /decision` request caused by unconditional `runErr.Error()`.
- Maps evaluation failures to RFC 9457 Problem Details with HTTP 400 (`InvalidInvocationError`) or 500 (other errors) instead of always returning HTTP 200 with an `error` string.
- Adds API integration tests covering success and failure paths using `example_pack`.

## What this PR does

- Guards the success path so `DecisionResponse` is only written when evaluation succeeds.
- Routes evaluation errors through `writeErrorResponse` with appropriate status codes.
- Skips nil `ExecRule` outputs so responses no longer contain `[null]` decision entries.
- Updates the codebase graph to remove resolved defect claims for #114.

## Changes by area

### API decision handler (`api/handle_decision.go`)

- Check `runErr != nil` before responding; use `errors.As` for `xerr.InvalidInvocationError` → 400, else 500.
- On success, return `{"decisions": [...]}` only (no `error` field).
- Append `ExecRule` output only when non-nil.
- Migrate SPDX header to two-line 2026 form.

### API tests (`api/handle_decision_test.go`)

- New `APITestSuite` methods using `httptest` and `example_pack`:
  - Policy success → 200, decisions present, no `error` key.
  - Rule success → 200, single non-null decision.
  - Missing required fact → 400 Problem Details.
  - Evaluation internal error (shapes policy) → 500 Problem Details.
  - Invalid path → 404; invalid JSON → 400.

### Codebase graph docs

- `docs/codebase-graph/api.handle_decision.md` — remove panic / always-200 / `[null]` gotchas; document evaluation error status mapping.
- `docs/codebase-graph/api.md` — remove success-path panic gotcha; update response contract.
- `docs/codebase-graph/api.problem_details.md` — note evaluation errors now use Problem Details.

## Review notes

- Confirm `InvalidInvocationError` → 400 and all other eval errors → 500 matches CLI/client expectations.
- `DecisionResponse.Error` field remains on the struct but is no longer populated by the handler; clients should rely on HTTP status + Problem Details for failures.
- `runConfig` query-parameter parsing is still dead code (unchanged).
- CORS, auth, and body-size limits remain out of scope ([#115](https://github.com/sentrie-sh/sentrie/issues/115)).

## Testing notes

- `GOWORK=off go test ./api/...` — all tests pass.
- `handle_decision.go` statement coverage: ~81% (new/changed logic).

## Dependency changes

- None.