### PR TITLE
Remove stray advance in parseNotExpression. Closes #95

### DIFF
--- a/docs/codebase-graph/parser.not.md
+++ b/docs/codebase-graph/parser.not.md
@@ -33,7 +33,7 @@ Handles the infix use of `not` - the negated membership and matching forms `x no
 - **Statefulness:** Stateless.
 - **Performance/Scale Notes:** Nothing notable.
 - **Dependencies Risk:**
-  - **Regression history.** This production previously carried a stray third `advance()` that swallowed the first token of the right operand, making *every* negated membership form unparseable (`9 not in [1, 2, 3]` failed with `unexpected token 'Comma'`). It is fixed and covered by `parser/not_test.go`; do not reintroduce a bare `advance()` between the operator and the operand parse.
-  - **The `lang_test/` fixtures do not run.** `lang_test/0014-matches-contains-in.sentrie` exercises all three forms, but no Go test harness references that directory, so nothing executes those fixtures in CI. They provide no regression protection for this or any other production.
+  - **Regression history.** A stray third `advance()` between the operator token and `parseExpression` swallowed the first token of the right operand, making negated membership forms unparseable (`9 not in [1, 2, 3]` failed with `unexpected token 'Comma'`). It is fixed and covered by `parser/not_test.go`; do not reintroduce a bare `advance()` between the operator and the operand parse.
+  - **The `lang_test/` fixtures do not run.** `lang_test/0014-matches-contains-in.sentrie` exercises all three forms, but no Go test harness references that directory, so nothing executes those fixtures in CI (see #103). They provide no regression protection for this or any other production.
   - **Right-operand precedence is inherited, not raised.** The operand is parsed at the caller's precedence rather than the operator's, which differs from [[parser.infix]] and may produce different associativity for chained forms.
   - **The desugaring is invisible in the AST.** `x not in y` and `not (x in y)` produce identical trees, so tooling cannot recover which spelling the author used.

--- a/parser/not.go
+++ b/parser/not.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package parser
 
@@ -35,7 +22,6 @@ func parseNotExpression(ctx context.Context, parser *Parser, left ast.Expression
 	opToken := parser.advance()
 	rnge.To = opToken.Range.To
 
-	parser.advance()
 	right := parser.parseExpression(ctx, precedence)
 	if right == nil {
 		return nil

--- a/parser/not_test.go
+++ b/parser/not_test.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/sentrie-sh/sentrie/ast"
+)
+
+func (s *ParserTestSuite) TestParseNotExpressionForms() {
+	s.T().Run("notInList", func(t *testing.T) {
+		parser := NewParserFromString("9 not in [1, 2, 3]", "test.sentrie")
+		expr := parser.parseExpression(s.T().Context(), LOWEST)
+		s.Require().NotNil(expr)
+
+		unary, ok := expr.(*ast.UnaryExpression)
+		s.Require().True(ok)
+		s.Equal("not", unary.Operator)
+
+		infix, ok := unary.Right.(*ast.InfixExpression)
+		s.Require().True(ok)
+		s.Equal("in", infix.Operator)
+
+		list, ok := infix.Right.(*ast.ListLiteral)
+		s.Require().True(ok)
+		s.Len(list.Values, 3)
+	})
+
+	s.T().Run("notContains", func(t *testing.T) {
+		parser := NewParserFromString(`["x", "y"] not contains "z"`, "test.sentrie")
+		expr := parser.parseExpression(s.T().Context(), LOWEST)
+		s.Require().NotNil(expr)
+		s.Equal(`not(["x", "y"] contains "z")`, expr.String())
+	})
+
+	s.T().Run("notMatches", func(t *testing.T) {
+		parser := NewParserFromString(`"foo" not matches "[0-9]+"`, "test.sentrie")
+		expr := parser.parseExpression(s.T().Context(), LOWEST)
+		s.Require().NotNil(expr)
+		s.Equal(`not("foo" matches "[0-9]+")`, expr.String())
+	})
+
+	s.T().Run("invalidNotOperand", func(t *testing.T) {
+		parser := NewParserFromString("9 not 3", "test.sentrie")
+		expr := parser.parseExpression(s.T().Context(), LOWEST)
+		s.Nil(expr)
+		s.Error(parser.err)
+		s.Contains(parser.err.Error(), "expected 'not', 'matches', 'contains', or 'in' after 'not'")
+	})
+}


### PR DESCRIPTION

## Summary

- Fixes parsing of negated membership forms (`not in`, `not contains`, `not matches`) by removing an extra `advance()` that consumed the first token of the right operand.
- Adds parser regression tests for all three forms plus an invalid `not` operand.
- Migrates `parser/not.go` SPDX header to the 2026 two-line form.

## What this PR does

- In `parseNotExpression`, after consuming the operator token (`in`, `contains`, `matches`), parse the right operand directly without a second `advance()`.
- Restores parseability of expressions such as `9 not in [1, 2, 3]` (previously failed with `unexpected token 'Comma'`).

## Changes by area

### Parser (`parser/not.go`)

- Remove stray `parser.advance()` between operator token and `parseExpression`.
- SPDX header → two-line 2026 form.

### Tests (`parser/not_test.go`)

- New `ParserTestSuite` methods on existing suite:
  - `notInList`: AST is `not (9 in [1, 2, 3])`.
  - `notContains` and `notMatches`: string form matches desugared output.
  - `invalidNotOperand`: `9 not 3` → parse error with expected message.

### Codebase graph

- `docs/codebase-graph/parser.not.md`: clarify regression history; cross-reference #103 for `lang_test` fixtures not running in CI.

## Review notes

- Do not reintroduce a bare `advance()` between the operator and operand parse.
- Right-operand precedence is still inherited from the caller (unchanged; documented gotcha).
- `lang_test/0014-matches-contains-in.sentrie` is not executed in CI (#103).

## Testing notes

- `GOWORK=off go test ./parser/ -run TestParseNotExpressionForms`
- `GOWORK=off go test ./parser/...`

## Dependency changes

- None.