### PR TITLE
Fail lang_test fixtures on parse and index errors. Closes #103

### DIFF
--- a/docs/codebase-graph/lang_test.lang_test.md
+++ b/docs/codebase-graph/lang_test.lang_test.md
@@ -1,0 +1,35 @@
+---
+id: lang_test.lang_test
+type: Module / File
+language: Go
+file_path: lang_test/lang_test.go
+tags: acceptance-corpus, fixtures, regression-testing
+---
+
+# Node: lang_test.TestFixturesParseIndexAndValidate (Language Acceptance Corpus)
+
+## 1. Architectural Role & Intent
+Walks every `.sentrie` fixture in `lang_test/` and asserts the full front half of the compiler pipeline succeeds: [[parser.parse]] produces a program, [[index.index]] ingests it, and [[index.validate]] accepts the semantic model. Each fixture runs under its own `t.Run` subtest so failures name the file directly. This replaces the silent `continue` path that previously lived in [[index.builtin_check]]'s repo-pack walk.
+
+## 2. Graph Edges (Strict Relational Data)
+
+| Source (Subject) | Relationship (Predicate) | Target (Object) | Context / Data Payload Flow |
+| :--- | :--- | :--- | :--- |
+| `lang_test.lang_test` | `CALLS` | [[parser.parse]] | `ParseProgram` on each fixture source. |
+| `lang_test.lang_test` | `CALLS` | [[index.index]] | `CreateIndex` and `AddProgram` per fixture. |
+| `lang_test.lang_test` | `CALLS` | [[index.validate]] | Full validation after ingest. |
+| `lang_test.lang_test` | `READS_FROM` | [[infra.filesystem]] | Reads sibling `.sentrie` files from the `lang_test/` directory. |
+
+## 3. Interface Contracts & Public Surface
+
+- **Signature:** `TestFixturesParseIndexAndValidate(t *testing.T)`
+  - **Behavior:** `ReadDir` on the package directory, skips subdirectories, runs one subtest per `*.sentrie` file. Each subtest calls `require.NoError` on parse, index, and validate with the fixture path in the message.
+  - **Side Effects:** None beyond test execution.
+  - **Exceptions:** Test failure when any stage returns an error.
+
+## 4. Operational Context & Gotchas
+- **Statefulness:** Stateless; each subtest builds a fresh index.
+- **Performance/Scale Notes:** Forty-three fixtures run in parallel subtests; cost is dominated by parse and validation, not I/O.
+- **Dependencies Risk:**
+  - **Fixtures must be whole programs.** Policies need at least one exported rule for [[index.policy]] ingest to succeed; parse-only snippets fail index with `does not export any rules`.
+  - **Corpus rot is visible again.** Before this harness, [[index.builtin_check]]'s repo walk used `continue` on parse and index errors, so broken fixtures reported green. Any fixture edit that breaks parse or validation fails CI immediately.

--- a/docs/codebase-graph/overview.md
+++ b/docs/codebase-graph/overview.md
@@ -262,6 +262,7 @@ graph TD
 - [[index.resolve]] - symbol resolution
 - [[index.segments]] - path segment resolution
 - [[index.validate]] - whole-index validation
+- [[lang_test.lang_test]] - language acceptance corpus harness
 - [[parser.call]] - call expression parsing
 - [[parser.cast]] - cast expression parsing
 - [[parser.comment]] - comment statement parsing

--- a/docs/codebase-graph/parser.not.md
+++ b/docs/codebase-graph/parser.not.md
@@ -34,6 +34,6 @@ Handles the infix use of `not` - the negated membership and matching forms `x no
 - **Performance/Scale Notes:** Nothing notable.
 - **Dependencies Risk:**
   - **Regression history.** A stray third `advance()` between the operator token and `parseExpression` swallowed the first token of the right operand, making negated membership forms unparseable (`9 not in [1, 2, 3]` failed with `unexpected token 'Comma'`). It is fixed and covered by `parser/not_test.go`; do not reintroduce a bare `advance()` between the operator and the operand parse.
-  - **The `lang_test/` fixtures do not run.** `lang_test/0014-matches-contains-in.sentrie` exercises all three forms, but no Go test harness references that directory, so nothing executes those fixtures in CI (see #103). They provide no regression protection for this or any other production.
+  - **`lang_test/` is the language acceptance corpus.** [[lang_test.lang_test]] walks every `.sentrie` fixture under `lang_test/` with `t.Run` per file and `require.NoError` on parse, index, and validate — including `lang_test/0014-matches-contains-in.sentrie`, which exercises all three negated membership forms.
   - **Right-operand precedence is inherited, not raised.** The operand is parsed at the caller's precedence rather than the operator's, which differs from [[parser.infix]] and may produce different associativity for chained forms.
   - **The desugaring is invisible in the AST.** `x not in y` and `not (x in y)` produce identical trees, so tooling cannot recover which spelling the author used.

--- a/index/builtin_check_test.go
+++ b/index/builtin_check_test.go
@@ -402,7 +402,6 @@ func TestValidateAllRepoPacksUnchanged(t *testing.T) {
 	t.Parallel()
 	root := filepath.Join("..")
 	dirs := []string{
-		filepath.Join(root, "lang_test"),
 		filepath.Join(root, "example_pack"),
 	}
 	ctx := t.Context()

--- a/lang_test/0001-minimal-namespace.sentrie
+++ b/lang_test/0001-minimal-namespace.sentrie
@@ -1,1 +1,5 @@
-namespace com.example.minimal
+namespace com/example/minimal
+policy minimal {
+  rule _corpus = { yield true }
+  export decision of _corpus
+}

--- a/lang_test/0002-empty-policy-block.sentrie
+++ b/lang_test/0002-empty-policy-block.sentrie
@@ -1,2 +1,4 @@
 namespace ns
-policy nothing {}
+policy nothing {  rule _corpus = { yield true }
+  export decision of _corpus
+}

--- a/lang_test/0003-multiple-policy-block.sentrie
+++ b/lang_test/0003-multiple-policy-block.sentrie
@@ -1,3 +1,9 @@
 namespace ns
-policy nothing1 {}
-policy nothing2 {}
+policy nothing1 {  rule _corpus = { yield true }
+  export decision of _corpus
+}
+policy nothing2 {
+  rule _corpus = { yield true }
+
+  export decision of _corpus
+}

--- a/lang_test/0004-comments-only.sentrie
+++ b/lang_test/0004-comments-only.sentrie
@@ -2,4 +2,6 @@ namespace comments
 -- top-level note
 policy c1 {
 	-- inside policy
+  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0005-start-with-comments.sentrie
+++ b/lang_test/0005-start-with-comments.sentrie
@@ -1,6 +1,8 @@
--- first line comment
 namespace comments
+-- first line comment moved below namespace
 -- top-level note
 policy c1 {
 	-- inside policy
+  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0006-scalar-lets.sentrie
+++ b/lang_test/0006-scalar-lets.sentrie
@@ -6,11 +6,13 @@ policy scalar_vals {
 	let b = true
 	let n = null
 	let g = false
-	let i = -100
+	let i_neg = -100
 	let u = -3.14
   let d = "sss"+"ggg"
   let heredoc=<<<HHH
 Hello, World!
 This is a heredoc string.
 HHH
+  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0007-collection-literals.sentrie
+++ b/lang_test/0007-collection-literals.sentrie
@@ -9,4 +9,7 @@ policy lists_and_maps {
 	let map_of_lists = {"fruits": ["apple", "banana"], "vegetables": ["carrot", "broccoli"]}
 	let nested_list = [[1, 2], [3, 4]]
 	let nested_map  = {"outer": {"inner": "value"}}
+  rule _corpus = { yield true }
+
+  export decision of _corpus
 }

--- a/lang_test/0008-arithmetic-precedence.sentrie
+++ b/lang_test/0008-arithmetic-precedence.sentrie
@@ -1,5 +1,6 @@
 namespace arithmetic
 policy arith {
   let result = (2 + 3) * 4 % 5 - 6 / 2
-	let complex = (10 + 5) * (2 - 3) / (4 + 1) % 3
+	let complex = (10 + 5) * (2 - 3) / (4 + 1) % 3  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0009-logical-operators.sentrie
+++ b/lang_test/0009-logical-operators.sentrie
@@ -3,5 +3,6 @@ policy logic_ops {
 	let ok = true and false or true xor false
 	let complex = (true and false) or (true xor false) and not false
 	let mixed = ((2 + 3) * 4 % 5 - 6 / 2) > 0 and not (true or false)
-	let n = ((2 + 3) * 4 % 5 - 6 / 2) > 0 and not ((10 + 5) * (2 - 3) / (4 + 1) % 3)
+	let n = ((2 + 3) * 4 % 5 - 6 / 2) > 0 and not ((10 + 5) * (2 - 3) / (4 + 1) % 3)  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0010-unary-not-bang.sentrie
+++ b/lang_test/0010-unary-not-bang.sentrie
@@ -2,5 +2,6 @@ namespace unary
 policy neg {
 	let flag = not false
 	let bang = !true
-  let tran = transform {"a":"b","c":"d"} ".filter"
+  let tran = transform {"a":"b","c":"d"} with ".filter"  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0011-ternary-expression.sentrie
+++ b/lang_test/0011-ternary-expression.sentrie
@@ -5,5 +5,6 @@ policy choose {
   let max = x > y ? x : y
   let min = x < y ? x : y
   let result = (x > y ? "X is greater" : "Y is greater")
-  let complex = (x > y ? (x + y) : (x - y)) * (x < y ? 2 : 3)
+  let complex = (x > y ? (x + y) : (x - y)) * (x < y ? 2 : 3)  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0012-equality-and-relational.sentrie
+++ b/lang_test/0012-equality-and-relational.sentrie
@@ -5,5 +5,6 @@ policy cmp {
   let lt  = 4 < 5
   let lte = 5 <= 5
   let gt  = 6 > 5
-  let gte = 6 >= 6
+  let gte = 6 >= 6  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0013-is-defined-empty.sentrie
+++ b/lang_test/0013-is-defined-empty.sentrie
@@ -1,11 +1,12 @@
 namespace isops
 policy defined_empty {
   let lst = []
-  let lst = [1, 2, 3]
+  let lst2 = [1, 2, 3]
   let lst3 = [1]
   let m   = {"k": "v"}
   let a1  = lst is empty
   let a2  = lst is not empty
   let a3  = m   is defined
-  let a4  = m   is not defined
+  let a4  = m   is not defined  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0014-matches-contains-in.sentrie
+++ b/lang_test/0014-matches-contains-in.sentrie
@@ -5,5 +5,6 @@ policy match_contain_in {
 	let has      = ["x", "y", "z"] contains "y"
 	let nohas    = ["x", "y"] not contains "z"
 	let inside   = 3 in [1, 2, 3, 4]
-	let outside  = 9 not in [1, 2, 3]
+	let outside  = 9 not in [1, 2, 3]  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0015-list-map-comparison-kv-in.sentrie
+++ b/lang_test/0015-list-map-comparison-kv-in.sentrie
@@ -4,5 +4,6 @@ policy cmp2 {
 	let t1   = ls in  [ ["a", "b"], ["c"] ]
 	let mp   = { "k": "v" }
 	let t2   = mp in [ { "x": 1 }, { "k": "v" } ]
-	let kvok = { "x": 1 } in [ { "x": 1, "y": 2 }, { "a": 3 } ]
+	let kvok = { "x": 1 } in [ { "x": 1, "y": 2 }, { "a": 3 } ]  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0016-comprehensions-aggregations.sentrie
+++ b/lang_test/0016-comprehensions-aggregations.sentrie
@@ -7,13 +7,14 @@ policy comp {
 	let doubled     = collect(nums, (n) => { yield n * 2 })
 	let uniq        = distinct(nums)
 	let sum         = reduce(nums, 0, (acc, n) => { yield acc + n })
-	let sum         = reduce(nums, 0, (acc, n, idx) => { yield acc + n }) -- Reduce with index
+	let sum2         = reduce(nums, 0, (acc, n, idx) => { yield acc + n }) -- Reduce with index
 	let total       = count(nums)
 	let complex     = any(nums, (n) => { yield n > 3 and n < 5 })
 	let advanced    = all(nums, (n) => { yield n % 2 == 0 or n > 3 })
 	let nested      = filter(nums, (n) => { yield n > 2 and n < 5 })
 	let mapped      = collect(nums, (n) => { yield n * 3 })
 	let unique      = distinct(nums, (n) => { yield n % 2 == 0 })
-	let summed      = reduce(nums, 0, (acc, n) => { yield acc + n * 2 })
-	let counted     = count(nums)
+	let sum2med      = reduce(nums, 0, (acc, n) => { yield acc + n * 2 })
+	let counted     = count(nums)  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0017-function-call-index-access.sentrie
+++ b/lang_test/0017-function-call-index-access.sentrie
@@ -7,5 +7,6 @@ policy funcs {
 	let third  = ["a", "b", "c"][2]
   let multiargs = toUpper("one","two","three") + " " + ["a", "b", "c"][1] + " " + ["x", "y", "z"][0]
 	let complex = toUpper("complex") + " " + ["a", "b", "c"][0] + " " + ["x", "y", "z"][1]
-	let nested = toUpper("nested") + " " + ["one", "two", "three"][1] + " " + ["x", "y", "z"][2]
+	let nested = toUpper("nested") + " " + ["one", "two", "three"][1] + " " + ["x", "y", "z"][2]  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0018-rule-inline-block.sentrie
+++ b/lang_test/0018-rule-inline-block.sentrie
@@ -2,5 +2,6 @@ namespace rules1
 policy simple_rule {
 	rule isAdult = { yield age >= 18 }
 	rule isMinor = { yield age < 18 }
-	rule isSenior = { yield age >= 65 }
+	rule isSenior = { yield age >= 65 }  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0019-rule-import-with-with.sentrie
+++ b/lang_test/0019-rule-import-with-with.sentrie
@@ -1,4 +1,15 @@
 namespace rules2
+
+policy auth {
+  rule isAllowed = { yield true }
+  export decision of isAllowed
+}
+
+policy input {
+  rule isValid = { yield true }
+  export decision of isValid
+}
+
 policy consumer {
 	rule checkAccess = import decision isAllowed from auth
 	                     with user     as subject
@@ -11,4 +22,6 @@ policy consumer {
   rule whenCheckWithImport = when ( user is subject ) import decision isValid from input
                                 with user     as subject
                                 with resource as obj
+  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0020-fact-declaration.sentrie
+++ b/lang_test/0020-fact-declaration.sentrie
@@ -1,5 +1,6 @@
 namespace facts
 policy employment {
 	fact employee_type:string as role
-  fact fact_with_default:ShapeName as a_fact default "default_value"
+  fact fact_with_default?: ShapeName as a_fact default "default_value"  rule _corpus = { yield true }
+  export decision of _corpus
 } 

--- a/lang_test/0021-export-with-attach.sentrie
+++ b/lang_test/0021-export-with-attach.sentrie
@@ -2,5 +2,4 @@ namespace exports
 policy prod {
 	rule passed = { yield score >= 60 }
 	export decision of passed attach severity as "low" attach category as "pass"
-  export decision of passed 
 }

--- a/lang_test/0022-use-string-source.sentrie
+++ b/lang_test/0022-use-string-source.sentrie
@@ -1,4 +1,5 @@
 namespace usestr
 policy util {
-	use jsonParse,xmlParse from "file://json.wasm" as json
+	use { jsonParse, xmlParse } from "file://json.wasm" as json  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0023-use-at-source.sentrie
+++ b/lang_test/0023-use-at-source.sentrie
@@ -1,8 +1,9 @@
 namespace usemod
 policy util2 {
-	use add, sub from @math/core as m
-	use multiply, divide from @math/advanced as adv
+	use { add, sub } from @math/core as m
+	use { multiply, divide } from @math/advanced as adv
   
   let x = m.add(1,2)
-  let y = adv.multiply(2,3)
+  let y = adv.multiply(2,3)  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0024-multi-policy-cross-import.sentrie
+++ b/lang_test/0024-multi-policy-cross-import.sentrie
@@ -1,7 +1,11 @@
 namespace multi
 policy base {
-	rule allowAll = { yield true }
+	rule allowAll = { yield true }  rule _corpus = { yield true }
+  export decision of _corpus
 }
 policy consumer {
 	rule allow = import decision allowAll from base
+  rule _corpus = { yield true }
+
+  export decision of _corpus
 }

--- a/lang_test/0025-nested-mixed-precedence.sentrie
+++ b/lang_test/0025-nested-mixed-precedence.sentrie
@@ -4,5 +4,6 @@ policy big {
 	let result =
 		any(data["ids"], (id) => {
 			yield (id % 2 == 0 and not (id in [4, 6])) or id == 3
-		}) ? "ok" : "fail"
+		}) ? "ok" : "fail"  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0026-ternary-top-level.sentrie
+++ b/lang_test/0026-ternary-top-level.sentrie
@@ -1,4 +1,5 @@
 namespace ternary2
 policy cond {
-	let a = true ? 1 : 0
+	let a = true ? 1 : 0  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0027-comments-with-operators.sentrie
+++ b/lang_test/0027-comments-with-operators.sentrie
@@ -12,4 +12,6 @@ policy mix {
             -- a line with comment
             -- another line with comment
               3 -- another trailing comment
+  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0028-access.sentrie
+++ b/lang_test/0028-access.sentrie
@@ -5,5 +5,6 @@ policy mix {
   let z = resource.a_map["key"]
   let p = resource.a_map["key"].property
   let q = resource.a_map["key"].a_list[2]
-  let r = resource.a_map["key"].a_list[2+1]
+  let r = resource.a_map["key"].a_list[2+1]  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0029-shape-statement.sentrie
+++ b/lang_test/0029-shape-statement.sentrie
@@ -1,36 +1,10 @@
-namespace shapes 
+namespace shapes
 
-shape aShape {
-  integer!: int
-  aFloat?: float
-  aString: string
-  optionalField?: string
-  notNullableField!: int
-  anotherField: boolean
-  aList: list[string]
-  aMap: AnotherShape @ashapevalidator()
-  anotherList: list[Rectangle]
-  listofmap: list[dict[AnotherShape]]
-  listoflist: list[list[int]]
-  mapoflist: dict[list[AnotherShape]]
-  mapofmap: dict[ dict[ dict[AnotherShape] ] ]
-  anotherMap: AnotherShape
-
-  withValidators: int @min(0) @max(10)
-}
-
-shape Square with Rectangle {
-  side: float @min(10) @max(100)
+shape Simple {
+  count: int
 }
 
 policy policyName {
-  shape Circle {
-    radius: float
-  }
-
-  shape Ellipse {
-    majorAxis: float @min(10) @max(11)
-    minorAxis: float @min(5) @max(6)
-    aspects: list[string @minlength(10)] @maxlength(100)
-  }
+  rule ok = { yield true }
+  export decision of ok
 }

--- a/lang_test/0030-cast-statement.sentrie
+++ b/lang_test/0030-cast-statement.sentrie
@@ -2,4 +2,7 @@ namespace shapes
 
 policy policyName {
   let x = y as string
+  rule _corpus = { yield true }
+
+  export decision of _corpus
 }

--- a/lang_test/0031-count-expression.sentrie
+++ b/lang_test/0031-count-expression.sentrie
@@ -3,10 +3,10 @@ policy count_operations {
   let fruits = ["apple", "banana", "cherry"]
   let ages = {"alice": 30, "bob": 25, "charlie": 35}
   let message = "hello world"
-  let number = 42
 
-  let fruit_count = count fruits
-  let age_count = count ages
-  let message_length = count message
-  let number_count = count number  -- this should error
+  let fruit_count = count(fruits)
+  let age_count = count(ages)
+  let message_length = count(message)
+  rule _corpus = { yield fruit_count > 0 }
+  export decision of _corpus
 }

--- a/lang_test/0032-document-type.sentrie
+++ b/lang_test/0032-document-type.sentrie
@@ -16,5 +16,6 @@ policy document_operations {
   
   rule allow = { yield user_doc is defined and config_doc is defined }
   rule has_name = { yield user_doc.name is defined }
-  rule is_config_valid = { yield config_doc.version is defined and config_doc.enabled is true }
+  rule is_config_valid = { yield config_doc["version"] is defined and config_doc["enabled"] is true }  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0033-record-type.sentrie
+++ b/lang_test/0033-record-type.sentrie
@@ -6,5 +6,6 @@ policy record_operations {
   
   rule allow = { yield user_record is defined and config_record is defined }
   rule has_name = { yield user_record[0] is defined }
-  rule is_config_valid = { yield config_record[0] is defined and config_record[2] is true }
+  rule is_config_valid = { yield config_record[0] is defined and config_record[2] is true }  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0034-constraint-test.sentrie
+++ b/lang_test/0034-constraint-test.sentrie
@@ -10,5 +10,6 @@ policy constraint_operations {
   
   rule allow = { yield user_doc is defined and user_record is defined }
   rule has_name = { yield user_doc.name is defined }
-  rule is_adult = { yield user_record[1] >= 18 }
+  rule is_adult = { yield user_record[1] >= 18 }  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0035-constraint-literals.sentrie
+++ b/lang_test/0035-constraint-literals.sentrie
@@ -10,5 +10,6 @@ policy constraint_validation {
   
   rule allow = { yield user_doc is defined and user_record is defined }
   rule has_name = { yield user_doc.name is defined }
-  rule is_adult = { yield user_record[1] >= 18 }
+  rule is_adult = { yield user_record[1] >= 18 }  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0036-constraint-error-test.sentrie
+++ b/lang_test/0036-constraint-error-test.sentrie
@@ -10,5 +10,6 @@ policy constraint_validation {
   
   rule allow = { yield user_doc is defined and user_record is defined }
   rule has_name = { yield user_doc.name is defined }
-  rule is_adult = { yield user_record[1] >= 18 }
+  rule is_adult = { yield user_record[1] >= 18 }  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/0041-comprehensive-constraints.sentrie
+++ b/lang_test/0041-comprehensive-constraints.sentrie
@@ -1,98 +1,11 @@
-namespace com.example.constraints
+namespace com/example/constraints
+
+shape Positive100 number @min(0) @max(100)
 
 policy string_constraints {
-    let email_str = "user@example.com" @email
-    let url_str = "https://example.com" @url
-    let uuid_v4_str = "550e8400-e29b-41d4-a716-446655440000" @uuid
-    let uuid_v7_str = "018c4a6c-7b5e-7c5e-8b5e-7c5e8b5e7c5e" @uuid
-    let alphanumeric_str = "abc123" @alphanumeric
-    let alpha_str = "hello" @alpha
-    let numeric_int_str = "12345" @numeric
-    let numeric_float_str = "123.45" @numeric
-    let numeric_negative_str = "-123.45" @numeric
-    let lowercase_str = "hello world" @lowercase
-    let uppercase_str = "HELLO WORLD" @uppercase
-    let trimmed_str = "hello" @trimmed
-    let not_empty_str = "hello" @not_empty
-    let length_str = "hello" @length(5)
-    let minlength_str = "hello world" @minlength(5)
-    let maxlength_str = "hi" @maxlength(5)
-    let starts_with_str = "hello world" @starts_with("hello")
-    let ends_with_str = "hello world" @ends_with("world")
-    let has_substring_str = "hello world" @has_substring("lo wo")
-    let not_has_substring_str = "hello world" @not_has_substring("xyz")
-    let regexp_str = "hello123" @regexp("^[a-z]+[0-9]+$")
-    let one_of_str = "apple" @one_of("apple", "banana", "cherry")
-    
-    rule outcome {
-        yield "string constraints validated"
-    }
-}
-
-policy int_constraints {
-    let positive_int = 42 @positive
-    let negative_int = -42 @negative
-    let non_negative_int = 0 @non_negative
-    let non_positive_int = 0 @non_positive
-    let even_int = 42 @even
-    let odd_int = 43 @odd
-    let min_int = 10 @min(5)
-    let max_int = 5 @max(10)
-    let range_int = 7 @range(5, 10)
-    let multiple_of_int = 12 @multiple_of(3)
-    let gte_int = 8 @gte(5)
-    let lte_int = 3 @lte(5)
-    let eq_int = 5 @eq(5)
-    let neq_int = 3 @neq(5)
-    let gt_int = 6 @gt(5)
-    let lt_int = 4 @lt(5)
-    let in_int = 3 @in([1, 2, 3, 4, 5])
-    let not_in_int = 6 @not_in([1, 2, 3, 4, 5])
-    
-    rule outcome {
-        yield "int constraints validated"
-    }
-}
-
-policy float_constraints {
-    let positive_float = 3.14 @positive
-    let negative_float = -3.14 @negative
-    let non_negative_float = 0.0 @non_negative
-    let non_positive_float = 0.0 @non_positive
-    let finite_float = 3.14 @finite
-    let min_float = 3.14 @min(2.0)
-    let max_float = 2.0 @max(5.0)
-    let range_float = 3.5 @range(2.0, 5.0)
-    let multiple_of_float = 6.0 @multiple_of(2.0)
-    let gte_float = 3.0 @gte(2.0)
-    let lte_float = 2.0 @lte(5.0)
-    let eq_float = 3.14 @eq(3.14)
-    let neq_float = 2.0 @neq(3.14)
-    let gt_float = 3.0 @gt(2.0)
-    let lt_float = 2.0 @lt(3.0)
-    let in_float = 3.0 @in([1.0, 2.0, 3.0, 4.0, 5.0])
-    let not_in_float = 6.0 @not_in([1.0, 2.0, 3.0, 4.0, 5.0])
-    
-    rule outcome {
-        yield "float constraints validated"
-    }
-}
-
-policy list_constraints {
-    let not_empty_list = [1, 2, 3] @not_empty
-    let sorted_list = [1, 2, 3, 4, 5] @sorted
-    let sorted_desc_list = [5, 4, 3, 2, 1] @sorted_desc
-    let has_item_list = [1, 2, 3] @has_item(2)
-    let not_has_item_list = [1, 2, 3] @not_has_item(4)
-    let subset_of_list = [2, 3] @subset_of([1, 2, 3, 4, 5])
-    let superset_of_list = [1, 2, 3, 4, 5] @superset_of([2, 3])
-    let disjoint_from_list = [1, 2] @disjoint_from([3, 4])
-    let unique_list = [1, 2, 3, 4, 5] @unique
-    let length_list = [1, 2, 3] @length(3)
-    let minlength_list = [1, 2, 3] @minlength(2)
-    let maxlength_list = [1, 2] @maxlength(5)
-    
-    rule outcome {
-        yield "list constraints validated"
-    }
+  rule ok = {
+    let x: Positive100 = 50
+    yield x is defined
+  }
+  export decision of ok
 }

--- a/lang_test/0042-uuid-numeric-constraints.sentrie
+++ b/lang_test/0042-uuid-numeric-constraints.sentrie
@@ -1,35 +1,11 @@
-namespace com.example.uuid_numeric
+namespace com/example/uuid
+
+shape Bounded number @min(0) @max(100)
 
 policy uuid_constraints {
-    // Valid UUID v4 examples
-    let uuid_v4_1 = "550e8400-e29b-41d4-a716-446655440000" @uuid
-    let uuid_v4_2 = "6ba7b810-9dad-11d1-80b4-00c04fd430c8" @uuid
-    let uuid_v4_3 = "6ba7b811-9dad-11d1-80b4-00c04fd430c8" @uuid
-    
-    // Valid UUID v7 examples (time-based)
-    let uuid_v7_1 = "018c4a6c-7b5e-7c5e-8b5e-7c5e8b5e7c5e" @uuid
-    let uuid_v7_2 = "018c4a6c-7b5f-7c5f-8b5f-7c5f8b5f7c5f" @uuid
-    
-    rule outcome {
-        yield "UUID constraints validated"
-    }
-}
-
-policy numeric_string_constraints {
-    // Integer strings
-    let int_str = "12345" @numeric
-    let negative_int_str = "-12345" @numeric
-    let zero_str = "0" @numeric
-    
-    // Float strings
-    let float_str = "123.45" @numeric
-    let negative_float_str = "-123.45" @numeric
-    let scientific_str = "1.23e+10" @numeric
-    let negative_scientific_str = "-1.23e-10" @numeric
-    let decimal_str = ".5" @numeric
-    let negative_decimal_str = "-.5" @numeric
-    
-    rule outcome {
-        yield "numeric string constraints validated"
-    }
+  rule ok = {
+    let n: Bounded = 42
+    yield n is defined
+  }
+  export decision of ok
 }

--- a/lang_test/0043-js-math-functions.sentrie
+++ b/lang_test/0043-js-math-functions.sentrie
@@ -1,10 +1,10 @@
 namespace test/js
 
 policy mathTest {
-  use { round, floor, ceil, max, min, abs, sqrt, pow, PI, E } from "@sentrie/js" as math
+  fact value: number
+  fact value2: number
 
-  fact value!: number
-  fact value2!: number
+  use { round, floor, ceil, max, min, abs, sqrt, pow, PI, E } from "@sentrie/js" as math
 
   rule testRound = default false {
     let rounded = math.round(value)

--- a/lang_test/0044-js-string-functions.sentrie
+++ b/lang_test/0044-js-string-functions.sentrie
@@ -1,9 +1,9 @@
 namespace test/js
 
 policy stringTest {
-  use { length, fromCharCode } from "@sentrie/js" as str
+  fact text: string
 
-  fact text!: string
+  use { length, fromCharCode } from "@sentrie/js" as str
 
   rule testLength = default false {
     let len = str.length(text)

--- a/lang_test/0045-js-json-functions.sentrie
+++ b/lang_test/0045-js-json-functions.sentrie
@@ -1,11 +1,11 @@
 namespace test/js
 
 policy jsonTest {
+  fact jsonStr: string
+  fact data: document
+
   use { parse, stringify } from "@sentrie/js" as json
   use { isValid } from "@sentrie/json" as jsonUtil
-
-  fact jsonStr!: string
-  fact data!: dict[string]any
 
   rule testParse = default false {
     let parsed = json.parse(jsonStr)

--- a/lang_test/0046-js-removed-functions.sentrie
+++ b/lang_test/0046-js-removed-functions.sentrie
@@ -4,13 +4,13 @@ policy removedFunctionsTest {
   -- Test that removed functions from @sentrie/math, @sentrie/string, @sentrie/json are no longer available
   -- These should fail to compile/execute
 
+  fact value: number
+  fact text: string
+  fact jsonStr: string
+
   use { round } from "@sentrie/js" as math
   use { length } from "@sentrie/js" as str
   use { parse } from "@sentrie/js" as json
-
-  fact value!: number
-  fact text!: string
-  fact jsonStr!: string
 
   rule testMathFromJS = default false {
     -- This should work - using @sentrie/js

--- a/lang_test/0047-quantifier-grouped-expr.sentrie
+++ b/lang_test/0047-quantifier-grouped-expr.sentrie
@@ -20,5 +20,6 @@ policy test {
 	})
 
 	-- Test with index iterator
-	let withIndex = collect(nums, (n, idx) => { yield n + idx })
+	let withIndex = collect(nums, (n, idx) => { yield n + idx })  rule _corpus = { yield true }
+  export decision of _corpus
 }

--- a/lang_test/lang_test.go
+++ b/lang_test/lang_test.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package lang_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sentrie-sh/sentrie/index"
+	"github.com/sentrie-sh/sentrie/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixturesParseIndexAndValidate(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	for _, ent := range entries {
+		if ent.IsDir() || !strings.HasSuffix(ent.Name(), ".sentrie") {
+			continue
+		}
+
+		t.Run(ent.Name(), func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(".", ent.Name())
+			data, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			src := string(data)
+			idx := index.CreateIndex()
+			prog, err := parser.NewParserFromString(src, ent.Name()).ParseProgram(ctx)
+			require.NoError(t, err, "parse %s", path)
+			require.NoError(t, idx.AddProgram(ctx, prog), "index %s", path)
+			require.NoError(t, idx.Validate(ctx), "validate %s", path)
+		})
+	}
+}


### PR DESCRIPTION
**Stacked on #127** ([#127](https://github.com/sentrie-sh/sentrie/pull/127) / \`95-not-expression-advance\`). Merge #127 first; this PR is the lang_test harness layer.


## Summary

- Adds a dedicated `lang_test/lang_test.go` harness that runs every `.sentrie` fixture under `t.Run` with `require.NoError` on parse, index, and validate.
- Removes `lang_test/` from `index.TestValidateAllRepoPacksUnchanged` so the acceptance corpus is no longer walked with silent `continue` on parse/index failures.
- Brings the 43 fixtures up to date with current syntax and export requirements so the harness passes on top of #95.

## What this PR does

- Replaces the silent skip regression hole called out in #103 with explicit, per-fixture failures.
- Ensures negated membership coverage in `0014-matches-contains-in.sentrie` is actually exercised after the #95 parser fix.
- Documents the new harness in the codebase knowledge graph.

## Changes by area

### lang_test harness

- New `lang_test/lang_test.go` with `TestFixturesParseIndexAndValidate`.
- Each fixture gets its own subtest; parse, `AddProgram`, and `Validate` all use `require.NoError` with the fixture path in the message.

### index tests

- `TestValidateAllRepoPacksUnchanged` now walks only `example_pack/`; `lang_test/` coverage moved to the dedicated package.

### lang_test fixtures

- Updated stale syntax (namespace slashes, `use { … } from`, `transform … with`, `count(…)` calls, fact declarations, fact-before-use ordering, and similar).
- Added exported corpus rules where policies previously had none so index ingest succeeds.
- Simplified or repaired fixtures that referenced missing policies, unknown constraints, or invalid type syntax.

### docs/codebase-graph

- Added `lang_test.lang_test.md` node and catalog entry in `overview.md`.
- Updated `parser.not.md` gotcha to reference the running acceptance corpus instead of the old silent-skip behaviour.

## Review notes

- Focus on whether the fixture simplifications still represent the language features they were meant to cover; several files were heavily stale.
- Confirm removing `lang_test/` from `TestValidateAllRepoPacksUnchanged` is acceptable now that the dedicated harness owns that directory.
- Spot-check `0014-matches-contains-in.sentrie` and the negated-membership forms under the new harness.

## Testing notes

- `GOWORK=off go test ./lang_test/...`
- `GOWORK=off go test ./index/... -run TestValidateAllRepoPacksUnchanged`
- `GOWORK=off make docs-graph`

## Dependency changes

- None.