### PR TITLE
Bypass memo cache when call hash key cannot be computed Closes #108

### DIFF
--- a/docs/codebase-graph/runtime.eval_call.md
+++ b/docs/codebase-graph/runtime.eval_call.md
@@ -47,10 +47,10 @@ The busiest node in the evaluator. It evaluates arguments, resolves the callee t
   - **Side Effects:** None.
   - **Exceptions:** `unknown derive %q`; visibility and not-exported errors.
 
-- **Signature:** `calculateHashKey(node *ast.CallExpression, args []box.Value) -> string`
-  - **Behavior:** Marshals arguments to boundary values, hashes them, and prefixes the **AST node pointer** so the key is per-call-site. Returns `""` on any failure.
+- **Signature:** `calculateHashKey(node *ast.CallExpression, args []box.Value) -> (string, error)`
+  - **Behavior:** Marshals arguments to boundary values, hashes them, and prefixes the **AST node pointer** so the key is per-call-site. Returns an error when marshalling or hashing fails.
   - **Side Effects:** None.
-  - **Exceptions:** None - failures are encoded as the empty string.
+  - **Exceptions:** Propagates `box.TryToBoundaryAny` and `hashstructure.Hash` failures.
 
 - **Signature:** `splitAliasFn(s string) -> (string, string)`
   - **Behavior:** Splits `alias.fn` on the first dot; returns `(s, "")` when there is no dot.
@@ -61,7 +61,7 @@ The busiest node in the evaluator. It evaluates arguments, resolves the callee t
 - **Statefulness:** Stateless per call, but reads and writes the executor's shared memoization cache.
 - **Performance/Scale Notes:** Memoized calls default to a **5 minute TTL** and share a 10 MB budget, so eviction is silent and a hot policy can thrash. Every module call marshals all arguments across the boundary. The `Precheck`/`Impl` split lets builtins short-circuit before doing work.
 - **Dependencies Risk:**
-  - **An unhashable memoized argument collapses onto the key `""`.** `calculateHashKey` returns the empty string on failure and the caller passes it straight to the cache, so unrelated calls become cache siblings and can receive each other's results. Filed as [#108](https://github.com/sentrie-sh/sentrie/issues/108).
+  - **Unhashable memoized arguments bypass the cache.** When `calculateHashKey` fails, the call is invoked directly rather than cached under an empty key.
   - **The precedence ladder must stay in sync with [[index.builtin_kind]]'s `isBuiltinCall`.** Static checking assumes local binding > derive > builtin; this function implements derive > builtin with locals handled earlier in [[runtime.eval_ident]]. Drift means checks are applied to a different callee than the one invoked.
   - **The three-segment floor for slash FQNs is a parser-ambiguity workaround.** `a/b` is division; `a/b/c` may be a derive. A genuinely two-segment derive FQN is therefore unreachable by slash syntax.
   - **Module resolution errors are misleading when the callee has no dot.** A bare unknown identifier that is not a derive or builtin falls through to `splitAliasFn`, yields an empty module name, and reports `ErrImportResolution` - an import error for what is really an unknown-function error.

--- a/runtime/eval_call.go
+++ b/runtime/eval_call.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2026 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package runtime
 
@@ -74,7 +61,11 @@ func evalCall(ctx context.Context, ec *ExecutionContext, exec *executorImpl, p *
 			ttl = *t.MemoizeTTL
 		}
 
-		hashKey := calculateHashKey(t, args)
+		hashKey, hashErr := calculateHashKey(t, args)
+		if hashErr != nil {
+			// Arguments cannot be hashed stably; bypass memoization.
+			return target(ctx, args...)
+		}
 		loader := func(ctx context.Context, key string) (any, error) {
 			return target(ctx, args...)
 		}
@@ -111,21 +102,24 @@ func splitAliasFn(s string) (string, string) {
 	return parts[0], parts[1]
 }
 
-func calculateHashKey(node *ast.CallExpression, args []box.Value) string {
+// calculateHashKey hashes memoization arguments and prefixes the AST call-site pointer.
+// The pointer is stable for the lifetime of the loaded index; the executor holds the index
+// and the memoization cache, so keys do not outlive their call sites.
+func calculateHashKey(node *ast.CallExpression, args []box.Value) (string, error) {
 	hashArgs := make([]any, 0, len(args))
 	for _, a := range args {
 		// Callables are rejected for memoized calls before we get here.
 		h, err := box.TryToBoundaryAny(a)
 		if err != nil {
-			return ""
+			return "", err
 		}
 		hashArgs = append(hashArgs, h)
 	}
 	arghash, err := hashstructure.Hash(hashArgs, hashstructure.FormatV2, nil)
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return fmt.Sprintf("%p:%d", node, arghash)
+	return fmt.Sprintf("%p:%d", node, arghash), nil
 }
 
 func lookupDeriveByIdentifier(ec *ExecutionContext, p *index.Policy, name string) *index.Derive {

--- a/runtime/eval_call_test.go
+++ b/runtime/eval_call_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"math"
 
+	"github.com/binaek/perch"
 	"github.com/sentrie-sh/sentrie/ast"
 	"github.com/sentrie-sh/sentrie/box"
 	"github.com/sentrie-sh/sentrie/builtins"
@@ -21,8 +22,10 @@ func stubRange() tokens.Range {
 
 func (s *RuntimeTestSuite) TestCalculateHashKeyDistinguishesUndefinedAndNull() {
 	node := &ast.CallExpression{}
-	undefinedHash := calculateHashKey(node, []box.Value{box.Undefined()})
-	nullHash := calculateHashKey(node, []box.Value{box.Null()})
+	undefinedHash, err := calculateHashKey(node, []box.Value{box.Undefined()})
+	s.Require().NoError(err)
+	nullHash, err := calculateHashKey(node, []box.Value{box.Null()})
+	s.Require().NoError(err)
 
 	s.Require().NotEmpty(undefinedHash)
 	s.Require().NotEmpty(nullHash)
@@ -75,8 +78,10 @@ func (s *RuntimeTestSuite) TestCalculateHashKeyMapKeyOrderStable() {
 	node := &ast.CallExpression{}
 	arg1 := box.Dict(map[string]box.Value{"a": box.Number(1), "b": box.Number(2)})
 	arg2 := box.Dict(map[string]box.Value{"b": box.Number(2), "a": box.Number(1)})
-	hash1 := calculateHashKey(node, []box.Value{arg1})
-	hash2 := calculateHashKey(node, []box.Value{arg2})
+	hash1, err := calculateHashKey(node, []box.Value{arg1})
+	s.Require().NoError(err)
+	hash2, err := calculateHashKey(node, []box.Value{arg2})
+	s.Require().NoError(err)
 	s.Require().Equal(hash1, hash2)
 }
 
@@ -85,16 +90,21 @@ func (s *RuntimeTestSuite) TestCalculateHashKeyNestedStructureStable() {
 	arg := box.List([]box.Value{
 		box.Dict(map[string]box.Value{"k": box.List([]box.Value{box.Number(1), box.String("x")})}),
 	})
-	hash := calculateHashKey(node, []box.Value{arg})
+	hash, err := calculateHashKey(node, []box.Value{arg})
+	s.Require().NoError(err)
 	s.Require().NotEmpty(hash)
 }
 
 func (s *RuntimeTestSuite) TestCalculateHashKeyNumericEdges() {
 	node := &ast.CallExpression{}
-	hashNegZero := calculateHashKey(node, []box.Value{box.Number(math.Copysign(0, -1))})
-	hashPosZero := calculateHashKey(node, []box.Value{box.Number(0)})
-	hashNaN := calculateHashKey(node, []box.Value{box.Number(math.NaN())})
-	hashInf := calculateHashKey(node, []box.Value{box.Number(math.Inf(1))})
+	hashNegZero, err := calculateHashKey(node, []box.Value{box.Number(math.Copysign(0, -1))})
+	s.Require().NoError(err)
+	hashPosZero, err := calculateHashKey(node, []box.Value{box.Number(0)})
+	s.Require().NoError(err)
+	hashNaN, err := calculateHashKey(node, []box.Value{box.Number(math.NaN())})
+	s.Require().NoError(err)
+	hashInf, err := calculateHashKey(node, []box.Value{box.Number(math.Inf(1))})
+	s.Require().NoError(err)
 
 	s.Require().NotEmpty(hashNaN)
 	s.Require().NotEmpty(hashInf)
@@ -229,15 +239,15 @@ func (s *RuntimeTestSuite) TestGetTargetModuleCallRejectsCallableArgument() {
 	s.Require().ErrorContains(err, "module call mod.fn")
 }
 
-func (s *RuntimeTestSuite) TestCalculateHashKeyCallableArgumentReturnsEmpty() {
+func (s *RuntimeTestSuite) TestCalculateHashKeyCallableArgumentReturnsError() {
 	node := &ast.CallExpression{}
-	hash := calculateHashKey(node, []box.Value{box.Callable(callableStub{
+	_, err := calculateHashKey(node, []box.Value{box.Callable(callableStub{
 		arity: 1,
 		fn: func(_ context.Context, _ []box.Value) (box.Value, error) {
 			return box.Undefined(), nil
 		},
 	})})
-	s.Require().Empty(hash)
+	s.Require().Error(err)
 }
 
 func (s *RuntimeTestSuite) TestLookupDeriveBySlashFQResolveErrorWithoutEvalDerive() {
@@ -295,4 +305,82 @@ policy pol {
 
 	_, err := lookupDeriveBySlashFQ(ec, exec, pol, "com/alpha/secret")
 	s.Require().Error(err)
+}
+
+func (s *RuntimeTestSuite) TestEvalCallMemoizedBypassesCacheForUnhashableArguments() {
+	ctx := s.T().Context()
+	p := newEvalTestPolicy()
+	exec := &executorImpl{
+		callMemoizePerch: perch.New[any](1 << 20),
+	}
+	exec.callMemoizePerch.Reserve()
+
+	const builtinName = "test_unhashable_memo_builtin"
+	original, hadOriginal := builtins.Table[builtinName]
+	defer func() {
+		if hadOriginal {
+			builtins.Table[builtinName] = original
+			return
+		}
+		delete(builtins.Table, builtinName)
+	}()
+
+	callCount := 0
+	builtins.Table[builtinName] = &builtins.Decl{
+		Name:        builtinName,
+		Description: "returns first argument for unhashable memo tests",
+		DeriveSafe:  true,
+		Sig: builtins.Sig{
+			Variadic:    &builtins.ParamSig{Name: "args"},
+			TooFewError: "",
+		},
+		Impl: func(_ context.Context, _ builtins.Env, args ...box.Value) (box.Value, error) {
+			callCount++
+			if len(args) > 0 {
+				return args[0], nil
+			}
+			return box.Undefined(), nil
+		},
+	}
+
+	callable := box.Callable(callableStub{
+		arity: 1,
+		fn: func(_ context.Context, _ []box.Value) (box.Value, error) {
+			return box.Undefined(), nil
+		},
+	})
+	listOne := box.List([]box.Value{box.Number(1), callable})
+	listTwo := box.List([]box.Value{box.Number(2), callable})
+
+	ec := NewExecutionContext(p, exec)
+	s.Require().NoError(ec.InjectFact(ctx, "arg_one", listOne, false, nil))
+	s.Require().NoError(ec.InjectFact(ctx, "arg_two", listTwo, false, nil))
+
+	callOne := ast.NewCallExpression(
+		ast.NewIdentifier(builtinName, stubRange()),
+		[]ast.Expression{ast.NewIdentifier("arg_one", stubRange())},
+		true,
+		nil,
+		stubRange(),
+	)
+	callTwo := ast.NewCallExpression(
+		ast.NewIdentifier(builtinName, stubRange()),
+		[]ast.Expression{ast.NewIdentifier("arg_two", stubRange())},
+		true,
+		nil,
+		stubRange(),
+	)
+
+	first, _, err := evalCall(ctx, ec, exec, p, callOne)
+	s.Require().NoError(err)
+	firstList, ok := first.ListValue()
+	s.Require().True(ok)
+	s.Require().Equal(1.0, firstList[0].Any())
+
+	second, _, err := evalCall(ctx, ec, exec, p, callTwo)
+	s.Require().NoError(err)
+	secondList, ok := second.ListValue()
+	s.Require().True(ok)
+	s.Require().Equal(2.0, secondList[0].Any())
+	s.Require().Equal(2, callCount)
 }


### PR DESCRIPTION

## Summary

- Memoized calls no longer share a cache entry under an empty hash key when argument hashing fails.
- `calculateHashKey` returns `(string, error)` and the caller bypasses the cache on failure.

## What this PR does

- Returns an error from `calculateHashKey` instead of the empty string on marshalling or hashing failure.
- Invokes the call target directly when no stable memo key is available.
- Documents the AST pointer key lifetime coupling in a comment.

## Changes by area

### Runtime evaluator

- Change `calculateHashKey` signature and memo wrapper in `runtime/eval_call.go`.
- Update hash-key tests and add unhashable nested-argument memo bypass test in `runtime/eval_call_test.go`.

### Codebase graph

- Update `docs/codebase-graph/runtime.eval_call.md` for the new contract and bypass behavior.

## Review notes

- Confirm memoized calls with nested unhashable values (e.g. lists containing callables) never cache under `""`.
- Callable top-level arguments remain rejected before hashing.

## Testing notes

- `GOWORK=off go test ./runtime -run 'RuntimeTestSuite/TestCalculateHashKey|RuntimeTestSuite/TestEvalCallMemoized'`
- `calculateHashKey` coverage ~90% on targeted test run.

## Dependency changes

- None.