### PR TITLE
Guard parseIsExpression when right operand parse fails Closes #96

### DIFF
--- a/docs/codebase-graph/parser.is.md
+++ b/docs/codebase-graph/parser.is.md
@@ -38,7 +38,7 @@ Parses the `is` family: `x is defined`, `x is empty`, their negated forms with a
 - **Statefulness:** Stateless.
 - **Performance/Scale Notes:** Nothing notable.
 - **Dependencies Risk:**
-  - **Regression history.** The general-comparison branch previously called `right.Span()` with no nil check, so a malformed right operand (`x is` at end of input) **panicked** instead of reporting a parse error. Fixed and covered by `parser/not_test.go`; keep the nil guard when touching this branch.
+  - **The general-comparison branch guards against a nil right operand** before calling `right.Span()`, matching [[parser.not]]; incomplete input such as `x is` records a parse error instead of panicking.
   - **The predicate spans are truncated.** `IsDefinedExpression` and `IsEmptyExpression` are built with the range of the `is` token captured *before* the follower is consumed, so their spans cover neither the left operand nor the `defined`/`empty` keyword.
   - **`defined` vs `null` are different questions.** `is defined` tests presence (the undefined sentinel in [[box.value]]), not nullness - a fact explicitly set to null **is** defined. Conflating them is the most common semantic mistake with this operator.
   - **`is not X` is desugared, not a distinct node**, so tooling cannot distinguish `x is not defined` from `not (x is defined)`.

--- a/parser/is.go
+++ b/parser/is.go
@@ -1,18 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 package parser
 
@@ -51,6 +38,9 @@ func parseIsExpression(ctx context.Context, p *Parser, left ast.Expression, prec
 		p.advance()
 	} else {
 		right := p.parseExpression(ctx, precedence)
+		if right == nil {
+			return nil
+		}
 		rnge.To = right.Span().To
 		expr = ast.NewInfixExpression(left, right, start.Value, rnge)
 	}

--- a/parser/is_test.go
+++ b/parser/is_test.go
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package parser
+
+// TestParseIsExpressionIncompleteRightOperand does not panic when the right side is missing.
+func (s *ParserTestSuite) TestParseIsExpressionIncompleteRightOperand() {
+	parser := NewParserFromString("x is", "test.sentra")
+	expr := parser.parseExpression(s.T().Context(), LOWEST)
+	s.Nil(expr)
+	s.Error(parser.err)
+}


### PR DESCRIPTION

## Summary

- Incomplete `is` expressions no longer panic the parser when the right operand is missing.
- Matches the nil guard pattern already used in `parseNotExpression`.

## What this PR does

- Returns `nil` from `parseIsExpression` when `parseExpression` fails for the right-hand side.
- Adds a regression test for input `x is` at end of file.

## Changes by area

### Parser

- Add nil guard before `right.Span()` in `parser/is.go`.
- Add `parser/is_test.go` regression test.
- Migrate `parser/is.go` SPDX header to the two-line 2026 form.

### Codebase graph

- Update `docs/codebase-graph/parser.is.md` for the nil guard behavior.

## Review notes

- Parser should record a diagnostic and return `nil` without panicking on partial `is` input.

## Testing notes

- `GOWORK=off go test ./parser -run 'ParserTestSuite/TestParseIsExpression'`

## Dependency changes

- None.