### PR TITLE
Iterate all statements in AddProgram and skip by type Closes #104

### DIFF
--- a/docs/codebase-graph/index.index.md
+++ b/docs/codebase-graph/index.index.md
@@ -44,9 +44,9 @@ tags: symbol-table, aggregate-root, concurrency, lifecycle
   - **Exceptions:** None.
 
 - **Signature:** `(*Index).AddProgram(ctx, astProgram *ast.Program) -> error`
-  - **Behavior:** Under the write lock: builds a `Program` record, ensures the namespace exists, then iterates all statements dispatching on type - comments and the namespace statement are skipped, shapes and policies created and registered, derives added with a **cloned snapshot** of the namespace's currently-visible derives, and shape/derive exports recorded. Finally registers the program under its file reference.
+  - **Behavior:** Under the write lock: rejects a second `NamespaceStatement`, builds a `Program` record, ensures the namespace exists, then iterates all statements dispatching on type - comments and the (single) namespace statement are skipped, shapes and policies created and registered, derives added with a **cloned snapshot** of the namespace's currently-visible derives, and shape/derive exports recorded. Finally registers the program under its file reference.
   - **Side Effects:** Mutates namespaces, policies, shapes, derives, and `Programs`.
-  - **Exceptions:** `ctx.Err()`; propagated conflicts from `addShape`/`addPolicy`/`addDerive`; `cannot export unknown derive %q at %s`; `unsupported top-level statement %T at %s`.
+  - **Exceptions:** `ctx.Err()`; `duplicate namespace statement at %s`; propagated conflicts from `addShape`/`addPolicy`/`addDerive`; `cannot export unknown derive %q at %s`; `unsupported top-level statement %T at %s`.
 
 - **Signature:** `(*Index).ensureNamespace(_, namespace *ast.NamespaceStatement) -> (*Namespace, error)`
   - **Behavior:** Returns the existing namespace or creates one, then scans **every** already-known namespace to wire parent/child links in both directions.
@@ -57,7 +57,7 @@ tags: symbol-table, aggregate-root, concurrency, lifecycle
 - **Statefulness:** Mutable aggregate with a strict lifecycle: populate → validate → commit → read. Not reusable after a failed validation.
 - **Performance/Scale Notes:** `ensureNamespace` is **O(n) over all namespaces per new namespace**, so building the tree is quadratic in namespace count. Fine for tens of namespaces; noticeable for thousands. `cloneDeriveMap` copies the visible-derive map on every derive registration.
 - **Dependencies Risk:**
-  - **Statement iteration starts at index 0** and skips namespace and comment statements by type, so leading comments do not cause the first declaration after them to be dropped.
+  - **Statement iteration starts at index 0** and skips comment statements by type. The first namespace statement is consumed by `createProgram`/`ensureNamespace`; a second `NamespaceStatement` is an error (`duplicate namespace statement`).
   - **Locking does not cover reads.** `theLock` is taken by `SetPack` and `AddProgram` only. `Validate`, `Commit`, and all resolution methods read unguarded, so an index must be fully populated before it is shared.
   - **The `validated`/`committed` flags are not used atomically.** They are plain `uint32` fields written inside the `Once` bodies; the real exactly-once guarantee comes from `sync.Once`, not from these. Do not read them as a concurrency signal.
   - **Derive visibility snapshots are taken here.** `cloneDeriveMap(ns.Derives)` captures what is visible *at that moment*, which is the mechanism behind the file-ordering constraint documented in [[index.derive]].

--- a/docs/codebase-graph/index.index.md
+++ b/docs/codebase-graph/index.index.md
@@ -44,7 +44,7 @@ tags: symbol-table, aggregate-root, concurrency, lifecycle
   - **Exceptions:** None.
 
 - **Signature:** `(*Index).AddProgram(ctx, astProgram *ast.Program) -> error`
-  - **Behavior:** Under the write lock: builds a `Program` record, ensures the namespace exists, then iterates statements **from index 1** dispatching on type - comments skipped, shapes and policies created and registered, derives added with a **cloned snapshot** of the namespace's currently-visible derives, and shape/derive exports recorded. Finally registers the program under its file reference.
+  - **Behavior:** Under the write lock: builds a `Program` record, ensures the namespace exists, then iterates all statements dispatching on type - comments and the namespace statement are skipped, shapes and policies created and registered, derives added with a **cloned snapshot** of the namespace's currently-visible derives, and shape/derive exports recorded. Finally registers the program under its file reference.
   - **Side Effects:** Mutates namespaces, policies, shapes, derives, and `Programs`.
   - **Exceptions:** `ctx.Err()`; propagated conflicts from `addShape`/`addPolicy`/`addDerive`; `cannot export unknown derive %q at %s`; `unsupported top-level statement %T at %s`.
 
@@ -57,7 +57,7 @@ tags: symbol-table, aggregate-root, concurrency, lifecycle
 - **Statefulness:** Mutable aggregate with a strict lifecycle: populate → validate → commit → read. Not reusable after a failed validation.
 - **Performance/Scale Notes:** `ensureNamespace` is **O(n) over all namespaces per new namespace**, so building the tree is quadratic in namespace count. Fine for tens of namespaces; noticeable for thousands. `cloneDeriveMap` copies the visible-derive map on every derive registration.
 - **Dependencies Risk:**
-  - **The `i := 1` loop start is a latent bug.** `AddProgram` assumes the namespace occupies statement zero, but [[parser.parse]] legally emits `CommentStatement` entries *before* it. For a file that opens with a comment, the statement at index 1 (the namespace itself, or the first real declaration) is skipped without any error.
+  - **Statement iteration starts at index 0** and skips namespace and comment statements by type, so leading comments do not cause the first declaration after them to be dropped.
   - **Locking does not cover reads.** `theLock` is taken by `SetPack` and `AddProgram` only. `Validate`, `Commit`, and all resolution methods read unguarded, so an index must be fully populated before it is shared.
   - **The `validated`/`committed` flags are not used atomically.** They are plain `uint32` fields written inside the `Once` bodies; the real exactly-once guarantee comes from `sync.Once`, not from these. Do not read them as a concurrency signal.
   - **Derive visibility snapshots are taken here.** `cloneDeriveMap(ns.Derives)` captures what is visible *at that moment*, which is the mechanism behind the file-ordering constraint documented in [[index.derive]].

--- a/index/derive_internal_coverage_test.go
+++ b/index/derive_internal_coverage_test.go
@@ -540,6 +540,24 @@ policy p {
 	s.Require().NoError(idx.AddProgram(ctx, prog))
 }
 
+func (s *IndexTestSuite) TestAddProgramRejectsDuplicateNamespaceStatement() {
+	ctx := s.T().Context()
+	idx := CreateIndex()
+	r := deriveCovRng(20)
+	prog := &ast.Program{
+		Reference: "two_ns.sentrie",
+		Statements: []ast.Statement{
+			ast.NewNamespaceStatement(ast.NewFQN([]string{"com", "one"}, r), r),
+			ast.NewNamespaceStatement(ast.NewFQN([]string{"com", "two"}, r), r),
+			ast.NewShapeStatement("User", ast.NewStringTypeRef(r), nil, r),
+		},
+	}
+	err := idx.AddProgram(ctx, prog)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "duplicate namespace statement")
+	s.Empty(idx.Programs)
+}
+
 func (s *IndexTestSuite) TestAddProgramRejectsUnsupportedNamespaceLevelFact() {
 	ctx := s.T().Context()
 	idx := CreateIndex()

--- a/index/index.go
+++ b/index/index.go
@@ -75,6 +75,22 @@ func (idx *Index) AddProgram(ctx context.Context, astProgram *ast.Program) error
 		return ctx.Err()
 	}
 
+	var extraNamespace ast.Statement
+	nsCount := 0
+	for _, stmt := range astProgram.Statements {
+		if _, ok := stmt.(*ast.NamespaceStatement); !ok {
+			continue
+		}
+		nsCount++
+		if nsCount > 1 {
+			extraNamespace = stmt
+			break
+		}
+	}
+	if extraNamespace != nil {
+		return fmt.Errorf("duplicate namespace statement at %s", extraNamespace.Span())
+	}
+
 	program := createProgram(astProgram)
 
 	ns, err := idx.ensureNamespace(ctx, program.Namespace)
@@ -88,6 +104,7 @@ func (idx *Index) AddProgram(ctx context.Context, astProgram *ast.Program) error
 			continue
 
 		case *ast.NamespaceStatement:
+			// The first (and only) namespace is consumed by createProgram/ensureNamespace.
 			continue
 
 		case *ast.ShapeStatement:

--- a/index/index.go
+++ b/index/index.go
@@ -1,6 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,10 +82,12 @@ func (idx *Index) AddProgram(ctx context.Context, astProgram *ast.Program) error
 		return err
 	}
 
-	for i := 1; i < len(astProgram.Statements); i++ {
-		stmt := astProgram.Statements[i]
+	for _, stmt := range astProgram.Statements {
 		switch s := stmt.(type) {
 		case *ast.CommentStatement:
+			continue
+
+		case *ast.NamespaceStatement:
 			continue
 
 		case *ast.ShapeStatement:

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -126,20 +126,17 @@ policy pol {
 }
 
 func (suite *IndexTestSuite) TestAddProgramRejectsDuplicateNamespace() {
-	ctx := suite.T().Context()
-	idx := CreateIndex()
-	src := `namespace com/example
-namespace com/other
+	stubRange := tokens.Range{File: "dup_ns.sentrie", From: tokens.Pos{Line: 1, Column: 0, Offset: 0}, To: tokens.Pos{Line: 1, Column: 10, Offset: 10}}
+	secondRange := tokens.Range{File: "dup_ns.sentrie", From: tokens.Pos{Line: 2, Column: 0, Offset: 0}, To: tokens.Pos{Line: 2, Column: 10, Offset: 10}}
+	program := &ast.Program{
+		Reference: "dup_ns.sentrie",
+		Statements: []ast.Statement{
+			ast.NewNamespaceStatement(ast.NewFQN([]string{"com", "example"}, stubRange), stubRange),
+			ast.NewNamespaceStatement(ast.NewFQN([]string{"com", "other"}, secondRange), secondRange),
+		},
+	}
 
-policy pol {
-  let _s = 0
-  rule r = { yield true }
-  export decision of r
-}
-`
-	prog, err := parser.NewParserFromString(src, "dup_ns.sentrie").ParseProgram(ctx)
-	suite.Require().NoError(err)
-	err = idx.AddProgram(ctx, prog)
+	err := suite.idx.AddProgram(suite.T().Context(), program)
 	suite.Require().Error(err)
 	suite.Contains(err.Error(), "duplicate namespace statement")
 }

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sentrie-sh/sentrie/ast"
 	"github.com/sentrie-sh/sentrie/pack"
+	"github.com/sentrie-sh/sentrie/parser"
 	"github.com/sentrie-sh/sentrie/tokens"
 	"github.com/sentrie-sh/sentrie/trinary"
 )
@@ -98,6 +99,31 @@ func (suite *IndexTestSuite) TestAddProgramWithSimpleShape() {
 	suite.Equal("com/example", ns.FQN.String())
 	suite.Len(ns.Shapes, 1)
 	suite.Contains(ns.Shapes, "User")
+}
+
+func (suite *IndexTestSuite) TestAddProgramWithLeadingCommentIndexesAllDeclarations() {
+	ctx := suite.T().Context()
+	idx := CreateIndex()
+	src := `-- a leading comment
+namespace com/example
+
+shape Foo { name: string }
+
+policy pol {
+  let _s = 0
+  rule r = { yield true }
+  export decision of r
+}
+`
+	prog, err := parser.NewParserFromString(src, "leading_comment.sentrie").ParseProgram(ctx)
+	suite.Require().NoError(err)
+	err = idx.AddProgram(ctx, prog)
+	suite.Require().NoError(err)
+
+	ns, ok := idx.Namespaces["com/example"]
+	suite.True(ok)
+	suite.Contains(ns.Shapes, "Foo")
+	suite.Contains(ns.Policies, "pol")
 }
 
 func (suite *IndexTestSuite) TestAddProgramWithPolicy() {

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -1,6 +1,5 @@
+// SPDX-FileCopyrightText: © 2026 Binaek Sarkar <binaek89@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
-//
-// Copyright 2025 Binaek Sarkar
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -124,6 +123,25 @@ policy pol {
 	suite.True(ok)
 	suite.Contains(ns.Shapes, "Foo")
 	suite.Contains(ns.Policies, "pol")
+}
+
+func (suite *IndexTestSuite) TestAddProgramRejectsDuplicateNamespace() {
+	ctx := suite.T().Context()
+	idx := CreateIndex()
+	src := `namespace com/example
+namespace com/other
+
+policy pol {
+  let _s = 0
+  rule r = { yield true }
+  export decision of r
+}
+`
+	prog, err := parser.NewParserFromString(src, "dup_ns.sentrie").ParseProgram(ctx)
+	suite.Require().NoError(err)
+	err = idx.AddProgram(ctx, prog)
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "duplicate namespace statement")
 }
 
 func (suite *IndexTestSuite) TestAddProgramWithPolicy() {


### PR DESCRIPTION

## Summary

- `AddProgram` no longer skips the statement at index 1 when leading comments precede the namespace.
- Namespace and comment statements are skipped by type instead of by position.

## What this PR does

- Iterates `astProgram.Statements` from index 0.
- Skips `CommentStatement` and `NamespaceStatement` explicitly in the switch.
- Adds a test with a leading comment, namespace, shape, and policy.

## Changes by area

### Index ingestion

- Fix statement loop in `index/index.go`.
- Add `TestAddProgramWithLeadingCommentIndexesAllDeclarations` in `index/index_test.go`.
- Migrate touched `index/index.go` SPDX header to the two-line 2026 form.

### Codebase graph

- Update `docs/codebase-graph/index.index.md` for the corrected iteration behavior.

## Review notes

- Files with one or more leading comments should index every declaration after the namespace.
- `createProgram` and `AddProgram` should now agree on walking all statements.

## Testing notes

- `GOWORK=off go test ./index -run 'IndexTestSuite/TestAddProgramWithLeadingComment'`

## Dependency changes

- None.