### PR TITLE
Fix ExecPolicy panic recovery locking and error join Closes #101

### DIFF
--- a/docs/codebase-graph/runtime.executor.md
+++ b/docs/codebase-graph/runtime.executor.md
@@ -69,7 +69,7 @@ The top-level driver: it owns the index, the JS registry, and the two caches, an
 - **Statefulness:** Long-lived and shared. Caches and VM pools outlive individual executions and are reused across concurrent calls.
 - **Performance/Scale Notes:** Every exported rule of a policy runs in parallel against shared caches. VM pools cap at 10 instances per module, so contention appears as latency, not errors. Module binding happens per `ExecRule`, but the underlying pool is cache-hit after the first use.
 - **Dependencies Risk:**
-  - **The panic recovery in `ExecPolicy` is itself racy.** The deferred `recover` assigns `compositeErr` **without holding `theLock`**, and assigns rather than joins - so a panic in one rule can race with, and clobber, errors recorded by others.
+  - **Panic recovery in `ExecPolicy` holds the mutex and joins errors**, including the panicking rule's name in the message, so concurrent rule failures are not lost or raced.
   - **`ExecPolicy` output order is nondeterministic.** It ranges over the `RuleExports` map and appends as goroutines finish, so callers must not rely on ordering.
   - **Module bindings are cached by module path alone.** The perch key is `ms.KeyOrPath()`, but the export restriction comes from the *first* `use` statement to populate that key. Two policies importing different named exports from the same module share one binding, so the second can observe a narrower exports map than it asked for.
   - **`defer done()` inside the attachment loop** accumulates trace closures until `execRule` returns rather than closing each span promptly; the same pattern appears in `evaluateRuleOutcome`.

--- a/runtime/executor.go
+++ b/runtime/executor.go
@@ -125,15 +125,21 @@ func (e *executorImpl) ExecPolicy(ctx context.Context, namespace, policy string,
 	var compositeErr error
 	outputs := make([]*ExecutorOutput, 0, len(p.RuleExports))
 	wg := &sync.WaitGroup{}
-	for _, ruleExport := range p.RuleExports {
+	for exportedName, ruleExport := range p.RuleExports {
+		ruleName := exportedName
+		if ruleExport != nil && ruleExport.RuleName != "" {
+			ruleName = ruleExport.RuleName
+		}
 		wg.Go(func() {
 			defer func() {
 				if r := recover(); r != nil {
-					compositeErr = stdErr.New("panic in ExecRule: " + fmt.Sprintf("%v", r))
+					theLock.Lock()
+					defer theLock.Unlock()
+					compositeErr = stdErr.Join(compositeErr, fmt.Errorf("panic in ExecRule %q: %v", ruleName, r))
 				}
 			}()
 
-			output, err := e.ExecRule(ctx, namespace, policy, ruleExport.RuleName, facts)
+			output, err := e.ExecRule(ctx, namespace, policy, ruleName, facts)
 
 			// now that we have the output, we can add it to the outputs slice,
 			// but we need to lock the mutex to avoid race conditions

--- a/runtime/executor_test.go
+++ b/runtime/executor_test.go
@@ -277,24 +277,94 @@ func (s *RuntimeTestSuite) TestExecPolicyRecoversPanicFromExecRule() {
 	}
 	idx.Namespaces[nsFQN.String()] = ns
 
+	fact := ast.NewFactStatement(
+		"userName",
+		ast.NewStringTypeRef(stubRange()),
+		"user",
+		ast.NewStringLiteral("default", stubRange()),
+		true,
+		stubRange(),
+	)
 	p := &index.Policy{
 		Namespace:   ns,
 		Name:        "pol",
 		FQN:         ast.CreateFQN(nsFQN, "pol"),
-		Facts:       map[string]*ast.FactStatement{},
+		Facts:       map[string]*ast.FactStatement{fact.Alias: fact},
 		Rules:       map[string]*index.Rule{},
 		RuleExports: map[string]*index.ExportedRule{},
 		Lets:        map[string]*ast.VarDeclaration{},
 		Uses:        map[string]*ast.UseStatement{},
 		Shapes:      map[string]*index.Shape{},
 	}
-	p.RuleExports["panicRule"] = nil
+	ruleStmt := ast.NewRuleStatement("allow", nil, nil, ast.NewTrinaryLiteral(trinary.True, stubRange()), stubRange())
+	rule := &index.Rule{
+		Node:   ruleStmt,
+		Policy: p,
+		Name:   "allow",
+		FQN:    ast.CreateFQN(p.FQN, "allow"),
+		Body:   ruleStmt.Body,
+	}
+	p.Rules["allow"] = rule
+	p.RuleExports["allow"] = &index.ExportedRule{RuleName: "allow"}
 	ns.Policies[p.Name] = p
 
 	exec := &executorImpl{index: idx}
 	_, err := exec.ExecPolicy(s.T().Context(), nsFQN.String(), p.Name, map[string]any{})
 	s.Require().Error(err)
-	s.Contains(err.Error(), "panic in ExecRule")
+	s.Contains(err.Error(), "panic in ExecRule \"allow\"")
+}
+
+func (s *RuntimeTestSuite) TestExecPolicyPanicRecoveryJoinsOtherRuleErrors() {
+	idx := index.CreateIndex()
+	nsFQN := ast.NewFQN([]string{"panic", "ns"}, stubRange())
+	ns := &index.Namespace{
+		FQN:          nsFQN,
+		Policies:     map[string]*index.Policy{},
+		Shapes:       map[string]*index.Shape{},
+		ShapeExports: map[string]*index.ExportedShape{},
+		Children:     []*index.Namespace{},
+	}
+	idx.Namespaces[nsFQN.String()] = ns
+
+	defaultFact := ast.NewFactStatement(
+		"userName",
+		ast.NewStringTypeRef(stubRange()),
+		"user",
+		ast.NewStringLiteral("default", stubRange()),
+		true,
+		stubRange(),
+	)
+	p := &index.Policy{
+		Namespace: ns,
+		Name:      "pol",
+		FQN:       ast.CreateFQN(nsFQN, "pol"),
+		Facts: map[string]*ast.FactStatement{
+			defaultFact.Alias: defaultFact,
+		},
+		Rules:       map[string]*index.Rule{},
+		RuleExports: map[string]*index.ExportedRule{},
+		Lets:        map[string]*ast.VarDeclaration{},
+		Uses:        map[string]*ast.UseStatement{},
+		Shapes:      map[string]*index.Shape{},
+	}
+	allowStmt := ast.NewRuleStatement("allow", nil, nil, ast.NewTrinaryLiteral(trinary.True, stubRange()), stubRange())
+	allowRule := &index.Rule{
+		Node:   allowStmt,
+		Policy: p,
+		Name:   "allow",
+		FQN:    ast.CreateFQN(p.FQN, "allow"),
+		Body:   allowStmt.Body,
+	}
+	p.Rules["allow"] = allowRule
+	p.RuleExports["allow"] = &index.ExportedRule{RuleName: "allow"}
+	p.RuleExports["ghost"] = &index.ExportedRule{RuleName: "ghost"}
+	ns.Policies[p.Name] = p
+
+	exec := &executorImpl{index: idx}
+	_, err := exec.ExecPolicy(s.T().Context(), nsFQN.String(), p.Name, map[string]any{})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "panic in ExecRule \"allow\"")
+	s.Contains(err.Error(), "not found")
 }
 
 func testExecutorForModuleBinding() *executorImpl {


### PR DESCRIPTION

## Summary

- `ExecPolicy` panic recovery now holds the shared mutex and joins into `compositeErr`.
- Panic messages include the exported rule name.

## What this PR does

- Locks `theLock` inside the `recover` defer before updating `compositeErr`.
- Uses `errors.Join` instead of assignment so panics supplement other rule errors.
- Captures rule names from map keys when export entries are nil.
- Extends executor tests for panic recovery and joined errors; runs under `-race`.

## Changes by area

### Runtime executor

- Fix `ExecPolicy` recovery path in `runtime/executor.go`.
- Update and extend tests in `runtime/executor_test.go`.

### Codebase graph

- Update `docs/codebase-graph/runtime.executor.md` for corrected recovery behavior.

## Review notes

- Concurrent exported rules: a panic in one goroutine must not race on `compositeErr` or discard errors from others.
- Recovery message format: `panic in ExecRule "<name>": <detail>`.

## Testing notes

- `GOWORK=off go test -race ./runtime -run 'RuntimeTestSuite/TestExecPolicy'`

## Dependency changes

- None.